### PR TITLE
Fix switch-test, and make the switch-test succeed!

### DIFF
--- a/src/decoder/serialized_frame.cc
+++ b/src/decoder/serialized_frame.cc
@@ -1,7 +1,7 @@
 #include "serialized_frame.hh"
+#include "file.hh"
 
 #include <fstream>
-#include <sstream>
 
 using namespace std;
 
@@ -24,13 +24,9 @@ SerializedFrame::SerializedFrame( const string & path )
     target_hash_( get_name( path ) ),
     output_raster_()
 {
-  ifstream file( path, ifstream::binary );
-  file.seekg( 0, file.end );
-  int size = file.tellg();
-  file.seekg( 0, file.beg );
-
-  frame_.resize( size );
-  file.read( reinterpret_cast<char *>(frame_.data()), size );
+  File file( path );
+  frame_.resize( file.chunk().size() );
+  memcpy( &frame_.at( 0 ), file.chunk().buffer(), file.chunk().size() );
 }
 
 SerializedFrame::SerializedFrame( const vector<uint8_t> & frame,

--- a/src/tests/switch-test
+++ b/src/tests/switch-test
@@ -11,8 +11,8 @@ sub switch_check {
   my $randsuffix = sprintf "%08X", rand(0xffffffff);
   my $dirname = "switch-dump$randsuffix";
 
-  system("../frontend/frameify $dirname $source_file $target_file") || exit;
-  system("../frontend/denseify $dirname $switch_num") || exit;
+  system("../frontend/frameify $dirname $source_file $target_file") and die "Failed framify";
+  system("../frontend/denseify $dirname $switch_num") and die "Failed denseify";
   my $frameify_sha1 = (split ' ', `./videodir-to-stdout $dirname $switch_num | sha1sum`)[ 0 ];
 
   rmtree [ $dirname ];

--- a/src/tests/videodir-to-stdout.cc
+++ b/src/tests/videodir-to-stdout.cc
@@ -40,8 +40,8 @@ int main( int argc, char * argv[] )
 
   vector<string> continuation_frames;
   while ( not frame_manifest.eof() ) {
-    string frame_name;
-    frame_manifest >> frame_name;
+    string frame_name, frame_size;
+    frame_manifest >> frame_name >> frame_size;
 
     if ( frame_name == "" ) {
       break;


### PR DESCRIPTION
The switch-test wasn't running, but when it does run, it fails in the SerializedFrame constructor by trying to allocate a gigantic vector:

````
keithw@pel:~/alfalfa/src/tests$ ./switch-test 
==14363==WARNING: AddressSanitizer failed to allocate 0xffffffffffffffff bytes
==14363==AddressSanitizer's allocator is terminating the process instead of returning 0
==14363==If you don't like this behavior set allocator_may_return_null=1
==14363==AddressSanitizer CHECK failed: ../../../../src/libsanitizer/sanitizer_common/sanitizer_allocator.cc:147 "((0)) != (0)" (0x0, 0x0)
    #0 0x7f1e46fa10b0 (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x5d0b0)
    #1 0x7f1e46fa5313 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x61313)
    #2 0x7f1e46f5d831 (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x19831)
    #3 0x7f1e46fa3b71 (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x5fb71)
    #4 0x7f1e46f9c146 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x58146)
    #5 0x41a8f4 in __gnu_cxx::new_allocator<unsigned char>::allocate(unsigned long, void const*) /usr/include/c++/4.9/ext/new_allocator.h:104
    #6 0x41a8f4 in std::allocator_traits<std::allocator<unsigned char> >::allocate(std::allocator<unsigned char>&, unsigned long) /usr/include/c++/4.9/bits/alloc_traits.h:357
    #7 0x41a8f4 in std::_Vector_base<unsigned char, std::allocator<unsigned char> >::_M_allocate(unsigned long) /usr/include/c++/4.9/bits/stl_vector.h:170
    #8 0x41a8f4 in std::vector<unsigned char, std::allocator<unsigned char> >::_M_default_append(unsigned long) /usr/include/c++/4.9/bits/vector.tcc:557
    #9 0x416949 in std::vector<unsigned char, std::allocator<unsigned char> >::resize(unsigned long) /usr/include/c++/4.9/bits/stl_vector.h:676
    #10 0x416949 in SerializedFrame::SerializedFrame(std::string const&) /home/keithw/alfalfa/src/decoder/serialized_frame.cc:32
    #11 0x40a28f in dump_frame_output(FramePlayer&, std::string const&) /home/keithw/alfalfa/src/tests/videodir-to-stdout.cc:14
    #12 0x40624f in main /home/keithw/alfalfa/src/tests/videodir-to-stdout.cc:87
    #13 0x7f1e45612a3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x20a3f)
    #14 0x409f98 in _start (/home/keithw/alfalfa/src/tests/videodir-to-stdout+0x409f98)

./switch-test: switch mismatch: expected 0816f3ddbd407c029b504945c7d2df66ffb8f7df, got afb20eefc8c9c7610be625467399e8cae9bdeb3d
````