### PR TITLE
Feature: alfalfa-encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Makefile.in
 /src/frontend/alfalfa-import
 /src/frontend/alfalfa-combine
 /src/frontend/alfalfa-describe
+/src/frontend/alfalfa-encode
 /src/tests/decode-to-stdout
 /src/tests/encode-loopback
 /src/tests/extract-key-frames

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - libxrandr-dev
     - libxi-dev
     - libglew-dev
+    - vpx-tools
 
 before_script:
   - curl -sSL https://ftp-master.debian.org/keys/archive-key-7.0.asc | sudo -E apt-key add -

--- a/src/decoder/frame_info.cc
+++ b/src/decoder/frame_info.cc
@@ -43,13 +43,6 @@ bool FrameInfo::shown() const
   return target_hash_.shown;
 }
 
-Chunk FrameInfo::chunk() const
-{
-  File file( ivf_filename_ );
-
-  return file( offset_, length_ );
-}
-
 std::string build_frame_name( const SourceHash & source_hash,
   const TargetHash & target_hash )
 {

--- a/src/decoder/frame_info.cc
+++ b/src/decoder/frame_info.cc
@@ -2,14 +2,13 @@
 #include "file.hh"
 
 FrameInfo::FrameInfo()
-  : ivf_filename_( ), offset_( 0 ), length_( 0 ), index_( 0 ), source_hash_(),
+  : offset_( 0 ), length_( 0 ), index_( 0 ), source_hash_(),
     target_hash_(), frame_id_( 0 )
 {}
 
-FrameInfo::FrameInfo( const std::string & ivf_filename, const std::string & frame_name,
+FrameInfo::FrameInfo( const std::string & frame_name,
                       const size_t & offset, const size_t & length )
-  : ivf_filename_( ivf_filename ),
-    offset_( offset ),
+  : offset_( offset ),
     length_( length ),
     index_( 0 ),
     source_hash_( frame_name ),
@@ -17,10 +16,9 @@ FrameInfo::FrameInfo( const std::string & ivf_filename, const std::string & fram
     frame_id_( 0 )
 {}
 
-FrameInfo::FrameInfo( const std::string & ivf_filename, const size_t & offset, const size_t & length,
+FrameInfo::FrameInfo( const size_t & offset, const size_t & length,
                       const SourceHash & source_hash, const TargetHash & target_hash )
-  : ivf_filename_( ivf_filename ),
-    offset_( offset ),
+  : offset_( offset ),
     length_( length ),
     index_( 0 ),
     source_hash_( source_hash ),

--- a/src/decoder/frame_info.hh
+++ b/src/decoder/frame_info.hh
@@ -56,8 +56,6 @@ public:
   bool validate_target( const DecoderHash & decoder_hash ) const;
   bool shown() const;
 
-  Chunk chunk() const;
-
   std::string str() const { return build_frame_name( source_hash_, target_hash_ ); }
 };
 

--- a/src/decoder/frame_info.hh
+++ b/src/decoder/frame_info.hh
@@ -16,7 +16,6 @@ std::string build_frame_name( const SourceHash & source_hash,
 class FrameInfo
 {
 private:
-  std::string ivf_filename_;
   size_t offset_;
   size_t length_;
   size_t index_;
@@ -26,7 +25,6 @@ private:
 
 public:
   std::string frame_name() const { return str(); }
-  std::string ivf_filename() const { return ivf_filename_; }
   size_t offset() const { return offset_; }
   size_t length() const { return length_; }
   size_t index() const { return index_; }
@@ -34,7 +32,6 @@ public:
   const SourceHash & source_hash() const { return source_hash_; }
   const TargetHash & target_hash() const { return target_hash_; }
 
-  void set_ivf_filename( const std::string & filename ) { ivf_filename_ = filename; }
   void set_source_hash( const SourceHash & source_hash ) { source_hash_ = source_hash; }
   void set_target_hash( const TargetHash & target_hash ) { target_hash_ = target_hash; }
   void set_offset( const size_t & offset ) { offset_ = offset; }
@@ -44,11 +41,10 @@ public:
 
   FrameInfo();
 
-  FrameInfo( const std::string & ivf_filename, const std::string & frame_name,
-             const size_t & offset, const size_t & length );
+  FrameInfo( const std::string & frame_name, const size_t & offset,
+             const size_t & length );
 
-  FrameInfo( const std::string & ivf_filename, const size_t & offset,
-             const size_t & length,
+  FrameInfo( const size_t & offset, const size_t & length,
              const SourceHash & source_hash,
              const TargetHash & target_hash );
 

--- a/src/decoder/player.cc
+++ b/src/decoder/player.cc
@@ -18,17 +18,6 @@ Optional<RasterHandle> FramePlayer::decode( const Chunk & chunk )
   return decoder_.parse_and_decode_frame( chunk );
 }
 
-Optional<RasterHandle> FramePlayer::decode( const FrameInfo & frame )
-{
-  assert( frame.validate_source( decoder_.get_hash() ) );
-
-  Optional<RasterHandle> raster = decoder_.parse_and_decode_frame( frame.chunk() );
-
-  assert( frame.validate_target( decoder_.get_hash() ) );
-
-  return raster;
-}
-
 bool FramePlayer::can_decode( const FrameInfo & frame ) const
 {
   // FIXME shouldn't have to fully hash this?

--- a/src/decoder/player.cc
+++ b/src/decoder/player.cc
@@ -70,7 +70,7 @@ FilePlayer::FilePlayer( const std::string & filename, IVF && file )
 FrameRawData FilePlayer::get_next_frame( void )
 {
   pair<uint64_t, uint32_t> frame_location = file_.frame_location( frame_no_ );
-  return { file_.frame( frame_no_++ ), frame_location.first, frame_location.second, filename_ };
+  return { file_.frame( frame_no_++ ), frame_location.first, frame_location.second };
 }
 
 RasterHandle FilePlayer::advance( void )

--- a/src/decoder/player.hh
+++ b/src/decoder/player.hh
@@ -15,7 +15,6 @@ struct FrameRawData
   Chunk chunk;
   uint64_t offset;
   uint32_t length;
-  std::string ivf_filename;
 };
 
 class FramePlayer

--- a/src/decoder/player.hh
+++ b/src/decoder/player.hh
@@ -26,12 +26,11 @@ private:
 
 protected:
   Decoder decoder_; // FIXME ideally this would be private
-  Optional<RasterHandle> decode( const Chunk & chunk );
 
 public:
   FramePlayer( const uint16_t width, const uint16_t height );
 
-  Optional<RasterHandle> decode( const FrameInfo & frame );
+  Optional<RasterHandle> decode( const Chunk & chunk );
 
   const VP8Raster & example_raster( void ) const;
 

--- a/src/decoder/tracking_player.cc
+++ b/src/decoder/tracking_player.cc
@@ -17,7 +17,7 @@ pair<FrameInfo, Optional<RasterHandle>> TrackingPlayer::decode_and_info( const F
   // Check this is a sane frame
   assert( source.get_hash().can_decode( source_hash ) );
 
-  return make_pair( FrameInfo( raw_data.ivf_filename, raw_data.offset, raw_data.length,
+  return make_pair( FrameInfo( raw_data.offset, raw_data.length,
                     source_hash, target_hash ), make_optional( output.first, output.second ) );
 }
 

--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -66,16 +66,23 @@ private:
   SwitchDB switch_db_;
   std::unordered_set<size_t> track_ids_;
   std::map<std::pair<size_t, size_t>, std::unordered_set<size_t>> switch_mappings_;
-  std::shared_ptr<File> ivf_file_;
+  Optional<File> ivf_file_;
+  Optional<IVFWriter> ivf_writer_;
+
+  void import_frame( FrameInfo next_frame,
+    const size_t & original_raster, const double & quality,
+    size_t & frame_id, size_t & frame_index, const size_t & track_id );
+
+  string prepare_ivf( const string & filename );
 
 public:
   AlfalfaVideo( const std::string & directory_name, OpenMode mode );
 
   bool can_combine( const AlfalfaVideo & video );
-  void combine( const AlfalfaVideo & video, IVFWriter & combined_ivf_writer );
-  void import( const std::string & filename,
-    Optional<AlfalfaVideo> original = Optional<AlfalfaVideo>(), const size_t & track_id = 0 );
-
+  void combine( const AlfalfaVideo & video );
+  void import( const std::string & filename );
+  void import( const std::string & filename, AlfalfaVideo & original,
+    const size_t & ref_track_id = 0 );
   void encode( const size_t & track_id, vector<string> vpxenc_args,
     const string & destination );
 
@@ -101,19 +108,26 @@ public:
 
   std::pair<std::unordered_set<size_t>::iterator, std::unordered_set<size_t>::iterator>
   get_track_ids();
+
   std::pair<std::unordered_set<size_t>::iterator, std::unordered_set<size_t>::iterator>
   get_track_ids_from_track( const size_t & from_track_id, const size_t & from_frame_index );
 
   std::pair<TrackDBIterator, TrackDBIterator> get_frames( const size_t & track_id );
   std::pair<TrackDBIterator, TrackDBIterator> get_frames( const TrackDBIterator & it );
   std::pair<TrackDBIterator, TrackDBIterator> get_frames( const SwitchDBIterator & it );
-  std::pair<SwitchDBIterator, SwitchDBIterator> get_frames( const TrackDBIterator & it, const size_t & to_track_id );
-  double get_quality( int raster_index, const FrameInfo & frame_info );
+  std::pair<SwitchDBIterator, SwitchDBIterator> get_frames( const TrackDBIterator & it,
+    const size_t & to_track_id );
 
+  double get_quality( int raster_index, const FrameInfo & frame_info );
   const Chunk get_chunk( const FrameInfo & frame_info ) const;
 
   bool good() const;
   bool save();
+
+  AlfalfaVideo( const AlfalfaVideo & other ) = delete;
+  AlfalfaVideo & operator=( const AlfalfaVideo & other ) = delete;
+
+  AlfalfaVideo( AlfalfaVideo && other );
 };
 
 #endif /* ALFALFA_VIDEO_HH */

--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -25,13 +25,15 @@
 #define SWITCH_DB_FILENAME "switch.db"
 #define VIDEO_MANIFEST_FILENAME "video.manifest"
 
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "db.hh"
 #include "ivf.hh"
-#include "manifests.hh"
+#include "player.hh"
 #include "frame_db.hh"
+#include "manifests.hh"
 #include "ivf_writer.hh"
 
 class AlfalfaVideo
@@ -71,7 +73,11 @@ public:
 
   bool can_combine( const AlfalfaVideo & video );
   void combine( const AlfalfaVideo & video, IVFWriter & combined_ivf_writer );
-  void import_ivf_file( const std::string & filename );
+  void import( const std::string & filename,
+    Optional<AlfalfaVideo> original = Optional<AlfalfaVideo>(), const size_t & track_id = 0 );
+
+  void encode( const size_t & track_id, vector<string> vpxenc_args,
+    const string & destination );
 
   VideoManifest & video_manifest() { return video_manifest_; }
   const VideoManifest video_manifest() const { return video_manifest_; }

--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -64,6 +64,7 @@ private:
   SwitchDB switch_db_;
   std::unordered_set<size_t> track_ids_;
   std::map<std::pair<size_t, size_t>, std::unordered_set<size_t>> switch_mappings_;
+  std::shared_ptr<File> ivf_file_;
 
 public:
   AlfalfaVideo( const std::string & directory_name, OpenMode mode );
@@ -102,6 +103,8 @@ public:
   std::pair<TrackDBIterator, TrackDBIterator> get_frames( const SwitchDBIterator & it );
   std::pair<SwitchDBIterator, SwitchDBIterator> get_frames( const TrackDBIterator & it, const size_t & to_track_id );
   double get_quality( int raster_index, const FrameInfo & frame_info );
+
+  const Chunk get_chunk( const FrameInfo & frame_info ) const;
 
   bool good() const;
   bool save();

--- a/src/format/db.cc
+++ b/src/format/db.cc
@@ -18,11 +18,6 @@ SerializableData::SerializableData( const std::string & filename, const std::str
     fin.close();
     break;
 
-  case OpenMode::APPEND:
-    fin.close();
-    good_ = true;
-    break;
-
   case OpenMode::TRUNCATE:
     fin.close();
     good_ = true;

--- a/src/format/db.hh
+++ b/src/format/db.hh
@@ -27,7 +27,6 @@ using boost::multi_index_container;
 enum class OpenMode
 {
   READ,
-  APPEND,
   TRUNCATE
 };
 
@@ -77,7 +76,7 @@ BasicDatabase<RecordType, RecordProtobufType, Collection, SequencedTag>
   OpenMode mode )
   : SerializableData( filename, magic_number, mode ), collection_()
 {
-  if ( good_ == true and ( mode == OpenMode::READ or mode == OpenMode::APPEND ) ) {
+  if ( good_ == true and ( mode == OpenMode::READ ) ) {
     good_ = deserialize();
   }
 }

--- a/src/format/manifests.cc
+++ b/src/format/manifests.cc
@@ -4,7 +4,7 @@ VideoManifest::VideoManifest( const std::string & filename, const std::string & 
   OpenMode mode )
     : SerializableData( filename, magic_number, mode ), info_()
 {
-  if ( good_ == true and ( mode == OpenMode::READ or mode == OpenMode::APPEND ) ) {
+  if ( good_ == true and ( mode == OpenMode::READ ) ) {
     good_ = deserialize();
   }
 }
@@ -121,17 +121,16 @@ TrackDB::search_by_track_id( const size_t & track_id )
   return index.equal_range( track_id );
 }
 
-bool
-TrackDB::has_track( const size_t & track_id )
+bool TrackDB::has_track( const size_t & track_id ) const
 {
-  TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
+  const TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
   return index.count( track_id ) > 0;
 }
 
 size_t
-TrackDB::get_end_frame_index( const size_t & track_id )
+TrackDB::get_end_frame_index( const size_t & track_id ) const
 {
-  TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
+  const TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
   return index.count( track_id );
 }
 

--- a/src/format/manifests.hh
+++ b/src/format/manifests.hh
@@ -204,8 +204,8 @@ public:
   // TODO(Deepak): Deprecate this
   std::pair<TrackDBCollectionByTrackIdAndFrameIndex::iterator, TrackDBCollectionByTrackIdAndFrameIndex::iterator>
   search_by_track_id( const size_t & track_id );
-  size_t get_end_frame_index( const size_t & track_id );
-  bool has_track( const size_t & track_id );
+  size_t get_end_frame_index( const size_t & track_id ) const;
+  bool has_track( const size_t & track_id ) const;
   const TrackData &
   get_frame( const size_t & track_id, const size_t & frame_index );
   void merge( const TrackDB & db, map<size_t, size_t> & frame_id_mapping );

--- a/src/format/protobufs/alfalfa.proto
+++ b/src/format/protobufs/alfalfa.proto
@@ -36,13 +36,12 @@ message RasterData {
 }
 
 message FrameInfo {
-  required string ivf_filename = 1;
-  required uint64 offset = 2;
-  required uint64 length = 3;
-  required SourceHash source_hash = 4;
-  required TargetHash target_hash = 5;
-  required uint64 frame_id = 6;
-  required uint64 index = 7;
+  required uint64 offset = 1;
+  required uint64 length = 2;
+  required SourceHash source_hash = 3;
+  required TargetHash target_hash = 4;
+  required uint64 frame_id = 5;
+  required uint64 index = 6;
 }
 
 message QualityData {

--- a/src/format/serialization.cc
+++ b/src/format/serialization.cc
@@ -155,8 +155,6 @@ void to_protobuf( const FrameInfo & fi, AlfalfaProtobufs::FrameInfo & message )
   message.set_offset( fi.offset() );
   message.set_length( fi.length() );
 
-  message.set_ivf_filename( fi.ivf_filename() );
-
   to_protobuf( fi.source_hash(), *message.mutable_source_hash() );
   to_protobuf( fi.target_hash(), *message.mutable_target_hash() );
 
@@ -176,7 +174,6 @@ void from_protobuf( const AlfalfaProtobufs::FrameInfo & pfi, FrameInfo & fi )
   fi.set_target_hash( target_hash );
   fi.set_offset( size_t( pfi.offset() ) );
   fi.set_length( size_t( pfi.length() ) );
-  fi.set_ivf_filename( pfi.ivf_filename() );
   fi.set_frame_id( size_t( pfi.frame_id() ) );
   fi.set_index( size_t( pfi.index() ) );
 }

--- a/src/format/serialization.hh
+++ b/src/format/serialization.hh
@@ -35,6 +35,20 @@ struct VideoInfo
   {
       return (double)frame_rate_numerator / frame_rate_denominator;
   }
+
+  bool operator==( const VideoInfo & other ) const
+  {
+    return ( fourcc == other.fourcc and
+      width == other.width and
+      height == other.height and
+      frame_rate_numerator == other.frame_rate_numerator and
+      frame_rate_denominator == other.frame_rate_denominator );
+  }
+
+  bool operator!=( const VideoInfo & other ) const
+  {
+    return not ( ( *this ) == other );
+  }
 };
 
 struct RasterData

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../decoder -I$(srcdir)/../format -I$(srcdir)/../display -I$(srcdir)/../encoder -I../format $(GLU_CFLAGS) $(GLEW_CFLAGS) $(GLFW3_CFLAGS) $(X264_CFLAGS) $(CXX11_FLAGS)
 AM_CXXFLAGS = $(PICKY_CXXFLAGS) $(NODEBUG_CXXFLAGS)
 
-bin_PROGRAMS = vp8decode vp8play collisions alfalfa-import alfalfa-combine alfalfa-describe
+bin_PROGRAMS = vp8decode vp8play collisions alfalfa-import alfalfa-combine alfalfa-describe alfalfa-encode
 
 vp8decode_SOURCES = vp8decode.cc
 vp8decode_LDADD = ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../display/libalfalfadisplay.a ../util/libalfalfautil.a $(X264_LIBS)
@@ -18,5 +18,9 @@ alfalfa_import_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalf
 alfalfa_combine_SOURCES = alfalfa-combine.cc
 alfalfa_combine_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../util/libalfalfautil.a $(X264_LIBS) $(PROTOBUF_LIBS)
 
+
 alfalfa_describe_SOURCES = alfalfa-describe.cc
 alfalfa_describe_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../util/libalfalfautil.a $(X264_LIBS) $(PROTOBUF_LIBS)
+
+alfalfa_encode_SOURCES = alfalfa-encode.cc
+alfalfa_encode_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../util/libalfalfautil.a $(X264_LIBS) $(PROTOBUF_LIBS)

--- a/src/frontend/alfalfa-combine.cc
+++ b/src/frontend/alfalfa-combine.cc
@@ -31,9 +31,9 @@ int main( int argc, char const *argv[] )
 
     FileSystem::create_directory( destination_dir );
 
-    AlfalfaVideo alf1( alf1_path, OpenMode::READ );
-    AlfalfaVideo alf2( alf2_path, OpenMode::READ );
-    AlfalfaVideo res_video( destination_dir, OpenMode::TRUNCATE );
+    PlayableAlfalfaVideo alf1( alf1_path );
+    PlayableAlfalfaVideo alf2( alf2_path );
+    WritableAlfalfaVideo res_video( destination_dir, alf1.video_manifest().info() );
 
     res_video.combine( alf1 );
     res_video.combine( alf2 );

--- a/src/frontend/alfalfa-combine.cc
+++ b/src/frontend/alfalfa-combine.cc
@@ -25,49 +25,18 @@ int main( int argc, char const *argv[] )
       return EX_USAGE;
     }
 
-    string alf1_path{ FileSystem::get_realpath( argv[ 1 ] ) };
-    string alf2_path{ FileSystem::get_realpath( argv[ 2 ] ) };
-    string destination_dir{ argv[ 3 ] };
+    string alf1_path( argv[ 1 ] );
+    string alf2_path( argv[ 2 ] );
+    string destination_dir( argv[ 3 ] );
 
     FileSystem::create_directory( destination_dir );
 
-    destination_dir = FileSystem::get_realpath( destination_dir );
-
-    FileSystem::change_directory( destination_dir );
-
     AlfalfaVideo alf1( alf1_path, OpenMode::READ );
     AlfalfaVideo alf2( alf2_path, OpenMode::READ );
+    AlfalfaVideo res_video( destination_dir, OpenMode::TRUNCATE );
 
-    if ( not alf1.good() ) {
-      cerr << "'" << alf1_path << "' is not a valid Alfalfa video." << endl;
-      return EX_DATAERR;
-    }
-
-    if ( not alf2.good() ) {
-      cerr << "'" << alf2_path << "' is not a valid Alfalfa video." << endl;
-      return EX_DATAERR;
-    }
-
-    if ( not alf1.can_combine( alf2 ) ) {
-      cerr << "cannot combine: raster lists are not the same." << endl;
-      return EX_DATAERR;
-    }
-
-    AlfalfaVideo res_video( ".", OpenMode::TRUNCATE );
-    const string new_ivf_filename = res_video.get_ivf_file_name();
-
-    // TODO: Make sure all the fields below are the same for alf1 and alf2
-
-    /* copy all frames into a single ivf file */
-    IVFWriter combined_ivf_writer( FileSystem::append( destination_dir, new_ivf_filename ),
-                                   alf1.video_manifest().fourcc(),
-                                   alf1.video_manifest().width(),
-                                   alf1.video_manifest().height(),
-                                   alf1.video_manifest().frame_rate_numerator(),
-                                   alf1.video_manifest().frame_rate_denominator() );
-
-    res_video.combine( alf1, combined_ivf_writer );
-    res_video.combine( alf2, combined_ivf_writer );
+    res_video.combine( alf1 );
+    res_video.combine( alf2 );
 
     res_video.save();
   } catch (const exception &e ) {

--- a/src/frontend/alfalfa-encode.cc
+++ b/src/frontend/alfalfa-encode.cc
@@ -1,0 +1,52 @@
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <sysexits.h>
+
+#include "exception.hh"
+#include "alfalfa_video.hh"
+#include "manifests.hh"
+#include "frame_db.hh"
+#include "tracking_player.hh"
+#include "filesystem.hh"
+#include "ivf_writer.hh"
+#include "temp_file.hh"
+
+using namespace std;
+
+int main( int argc, char const *argv[] )
+{
+  try {
+    if ( argc < 4 ) {
+      cerr << "Usage: " << argv[ 0 ] << " <alf-video> <track-id> <destination-dir> [vpxenc args]" << endl;
+      return EX_USAGE;
+    }
+
+    const string source_path( argv[ 1 ] );
+    const size_t track_id = atoi( argv[ 2 ] );
+    const string destination_dir( argv[ 3 ] );
+
+    AlfalfaVideo source_video( source_path, OpenMode::READ );
+
+    FileSystem::create_directory( destination_dir );
+    AlfalfaVideo alfalfa_video( destination_dir, OpenMode::TRUNCATE );
+
+    vector<string> vpxenc_args;
+    for_each( argv + 4, argv + argc, [ & vpxenc_args ]( const char * arg ) {
+        vpxenc_args.push_back( arg );
+      }
+    );
+
+    TempFile encoded_file( "encoded" );
+
+    source_video.encode( track_id, vpxenc_args, encoded_file.name() );
+    alfalfa_video.import( encoded_file.name(), make_optional( true, source_video ),
+      track_id );
+  } catch ( const exception & e ) {
+    print_exception( argv[ 0 ], e );
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/frontend/alfalfa-encode.cc
+++ b/src/frontend/alfalfa-encode.cc
@@ -27,10 +27,9 @@ int main( int argc, char const *argv[] )
     const size_t track_id = atoi( argv[ 2 ] );
     const string destination_dir( argv[ 3 ] );
 
-    AlfalfaVideo source_video( source_path, OpenMode::READ );
+    PlayableAlfalfaVideo source_video( source_path );
 
     FileSystem::create_directory( destination_dir );
-    AlfalfaVideo alfalfa_video( destination_dir, OpenMode::TRUNCATE );
 
     vector<string> vpxenc_args;
     for_each( argv + 4, argv + argc, [ & vpxenc_args ]( const char * arg ) {
@@ -39,8 +38,9 @@ int main( int argc, char const *argv[] )
     );
 
     TempFile encoded_file( "encoded" );
-
     source_video.encode( track_id, vpxenc_args, encoded_file.name() );
+
+    WritableAlfalfaVideo alfalfa_video( destination_dir, IVF( encoded_file.name() ) );
     alfalfa_video.import( encoded_file.name(), source_video, track_id );
   } catch ( const exception & e ) {
     print_exception( argv[ 0 ], e );

--- a/src/frontend/alfalfa-encode.cc
+++ b/src/frontend/alfalfa-encode.cc
@@ -41,8 +41,7 @@ int main( int argc, char const *argv[] )
     TempFile encoded_file( "encoded" );
 
     source_video.encode( track_id, vpxenc_args, encoded_file.name() );
-    alfalfa_video.import( encoded_file.name(), make_optional( true, source_video ),
-      track_id );
+    alfalfa_video.import( encoded_file.name(), source_video, track_id );
   } catch ( const exception & e ) {
     print_exception( argv[ 0 ], e );
     return EXIT_FAILURE;

--- a/src/frontend/alfalfa-import.cc
+++ b/src/frontend/alfalfa-import.cc
@@ -19,35 +19,16 @@ int main( int argc, char const *argv[] )
       return EX_USAGE;
     }
 
+    const string ivf_file( argv[ 1 ] );
     const string destination_dir( argv[ 2 ] );
 
-    IVF ivf_file( argv[ 1 ] );
-  
     FileSystem::create_directory( destination_dir );
     AlfalfaVideo alfalfa_video( destination_dir, OpenMode::TRUNCATE );
-
-    const string new_ivf_filename = alfalfa_video.get_ivf_file_name();
-
-    /* copy each frame into a new file, then close the file */
-    {
-      IVFWriter imported_ivf_file( FileSystem::append( destination_dir, new_ivf_filename ),
-				   ivf_file.fourcc(),
-				   ivf_file.width(),
-				   ivf_file.height(),
-				   ivf_file.frame_rate(),
-				   ivf_file.time_scale() );
-
-      /* copy each frame */
-      for ( unsigned int i = 0; i < ivf_file.frame_count(); i++ ) {
-	imported_ivf_file.append_frame( ivf_file.frame( i ) );
-      }
-    }
-  
-    alfalfa_video.import_ivf_file( new_ivf_filename );
+    alfalfa_video.import( ivf_file );
   } catch ( const exception & e ) {
     print_exception( argv[ 0 ], e );
     return EXIT_FAILURE;
   }
-    
+
   return EXIT_SUCCESS;
 }

--- a/src/frontend/alfalfa-import.cc
+++ b/src/frontend/alfalfa-import.cc
@@ -20,10 +20,12 @@ int main( int argc, char const *argv[] )
     }
 
     const string ivf_file( argv[ 1 ] );
+    const IVF ivf( ivf_file );
     const string destination_dir( argv[ 2 ] );
 
     FileSystem::create_directory( destination_dir );
-    AlfalfaVideo alfalfa_video( destination_dir, OpenMode::TRUNCATE );
+    WritableAlfalfaVideo alfalfa_video( destination_dir, ivf );
+
     alfalfa_video.import( ivf_file );
   } catch ( const exception & e ) {
     print_exception( argv[ 0 ], e );

--- a/src/tests/combine-test.cc
+++ b/src/tests/combine-test.cc
@@ -18,7 +18,7 @@ int alfalfa_combine_test_double_import( string ivf_file_path, string alfalfa_vid
   TrackDB & track_db = alfalfa_video.track_db();
 
   TrackingPlayer player( ivf_file_path );
-  size_t frame_index = 1;
+  size_t frame_index = 0;
 
   while ( not player.eof() ) {
     FrameInfo next_frame( player.serialize_next().first );
@@ -26,44 +26,46 @@ int alfalfa_combine_test_double_import( string ivf_file_path, string alfalfa_vid
     const size_t raster = next_frame.target_hash().output_hash;
     const size_t approximate_raster = raster;
 
-    // Check raster_list
-    if ( not raster_list.has( raster ) )
-      return 1;
-
-    // Check quality db
-    found = false;
-    auto it_orig = 
-      quality_db.search_by_original_raster( raster );
-    QualityDBCollectionByOriginalRaster::iterator it_begin_orig = it_orig.first;
-    QualityDBCollectionByOriginalRaster::iterator it_end_orig = it_orig.second;
-    while ( it_begin_orig != it_end_orig ) {
-      if ( it_begin_orig->original_raster != raster )
+    if ( next_frame.target_hash().shown ) {
+      // Check raster_list
+      if ( not raster_list.has( raster ) )
         return 1;
-      if ( it_begin_orig->approximate_raster == approximate_raster ) {
-        if ( it_begin_orig->quality == 1.0 )
-          found = true;
-      }
-      it_begin_orig++;
-    }
-    if ( !found )
-      return 1;
 
-    found = false;
-    auto it_approx =
-      quality_db.search_by_approximate_raster( approximate_raster );
-    QualityDBCollectionByApproximateRaster::iterator it_begin_approx = it_approx.first;
-    QualityDBCollectionByApproximateRaster::iterator it_end_approx = it_approx.second;
-    while ( it_begin_approx != it_end_approx ) {
-      if ( it_begin_approx->approximate_raster != approximate_raster )
-        return 1;
-      if ( it_begin_approx->original_raster == raster ) {
-        if ( it_begin_approx->quality == 1.0 )
-          found = true;
+      // Check quality db
+      found = false;
+      auto it_orig =
+        quality_db.search_by_original_raster( raster );
+      QualityDBCollectionByOriginalRaster::iterator it_begin_orig = it_orig.first;
+      QualityDBCollectionByOriginalRaster::iterator it_end_orig = it_orig.second;
+      while ( it_begin_orig != it_end_orig ) {
+        if ( it_begin_orig->original_raster != raster )
+          return 1;
+        if ( it_begin_orig->approximate_raster == approximate_raster ) {
+          if ( it_begin_orig->quality == 1.0 )
+            found = true;
+        }
+        it_begin_orig++;
       }
-      it_begin_approx++;
+      if ( !found )
+        return 1;
+
+      found = false;
+      auto it_approx =
+        quality_db.search_by_approximate_raster( approximate_raster );
+      QualityDBCollectionByApproximateRaster::iterator it_begin_approx = it_approx.first;
+      QualityDBCollectionByApproximateRaster::iterator it_end_approx = it_approx.second;
+      while ( it_begin_approx != it_end_approx ) {
+        if ( it_begin_approx->approximate_raster != approximate_raster )
+          return 1;
+        if ( it_begin_approx->original_raster == raster ) {
+          if ( it_begin_approx->quality == 1.0 )
+            found = true;
+        }
+        it_begin_approx++;
+      }
+      if ( !found )
+        return 1;
     }
-    if ( !found )
-      return 1;
 
     // Check frame db
     found = false;
@@ -116,7 +118,7 @@ int alfalfa_combine_test_double_import( string ivf_file_path, string alfalfa_vid
     if ( !found ) {
       return 1;
     }
-    
+
     frame_index++;
   }
 

--- a/src/tests/framedb-benchmark.cc
+++ b/src/tests/framedb-benchmark.cc
@@ -31,7 +31,7 @@ int main()//( int argc, char const *argv[] )
   while ( getline( fin, line ) ) {
     istringstream ss( line );
     ss >> frame_name >> offset;
-    FrameInfo fd( "test.ivf", frame_name, offset, 100 );
+    FrameInfo fd( frame_name, offset, 100 );
     fdb.insert(fd);
   }
 
@@ -46,7 +46,7 @@ int main()//( int argc, char const *argv[] )
   while ( getline( fin, line ) ) {
     istringstream ss( line );
     ss >> q >> frame_name;
-    FrameInfo fd( "test.ivf", frame_name, 0, 0 );
+    FrameInfo fd( frame_name, 0, 0 );
 
     if( q >= streams.size() ) {
       streams.resize( q + 1 );

--- a/src/tests/framedb-test.cc
+++ b/src/tests/framedb-test.cc
@@ -29,7 +29,7 @@ int main()
     TargetHash target_hash( update_tracker, i * 1234 + 5, i * 1234 + 6,
       i * 1234 + 7, ( i % 5 ) &  1 );
 
-    FrameInfo fi( "test-1.ivf", i * 4312, i * 2134, source_hash, target_hash );
+    FrameInfo fi( i * 4312, i * 2134, source_hash, target_hash );
 
     fdb1.insert( fi );
   }

--- a/src/tests/import-test.cc
+++ b/src/tests/import-test.cc
@@ -17,7 +17,7 @@ int alfalfa_import_test( string ivf_file_path, string alfalfa_video_dir ) {
   TrackDB & track_db = alfalfa_video.track_db();
 
   TrackingPlayer player( ivf_file_path );
-  size_t frame_index = 1;
+  size_t frame_index = 0;
 
   while ( not player.eof() ) {
     FrameInfo next_frame( player.serialize_next().first );
@@ -25,44 +25,46 @@ int alfalfa_import_test( string ivf_file_path, string alfalfa_video_dir ) {
     const size_t raster = next_frame.target_hash().output_hash;
     const size_t approximate_raster = raster;
 
-    // Check raster_list
-    if ( not raster_list.has( raster ) )
-      return 1;
-
-    // Check quality db
-    found = false;
-    auto it_orig = 
-      quality_db.search_by_original_raster( raster );
-    QualityDBCollectionByOriginalRaster::iterator it_begin_orig = it_orig.first;
-    QualityDBCollectionByOriginalRaster::iterator it_end_orig = it_orig.second;
-    while ( it_begin_orig != it_end_orig ) {
-      if ( it_begin_orig->original_raster != raster )
+    if ( next_frame.target_hash().shown ) {
+      // Check raster_list
+      if ( not raster_list.has( raster ) )
         return 1;
-      if ( it_begin_orig->approximate_raster == approximate_raster ) {
-        if ( it_begin_orig->quality == 1.0 )
-          found = true;
-      }
-      it_begin_orig++;
-    }
-    if ( !found )
-      return 1;
 
-    found = false;
-    auto it_approx =
-      quality_db.search_by_approximate_raster( approximate_raster );
-    QualityDBCollectionByApproximateRaster::iterator it_begin_approx = it_approx.first;
-    QualityDBCollectionByApproximateRaster::iterator it_end_approx = it_approx.second;
-    while ( it_begin_approx != it_end_approx ) {
-      if ( it_begin_approx->approximate_raster != approximate_raster )
-        return 1;
-      if ( it_begin_approx->original_raster == raster ) {
-        if ( it_begin_approx->quality == 1.0 )
-          found = true;
+      // Check quality db
+      found = false;
+      auto it_orig =
+        quality_db.search_by_original_raster( raster );
+      QualityDBCollectionByOriginalRaster::iterator it_begin_orig = it_orig.first;
+      QualityDBCollectionByOriginalRaster::iterator it_end_orig = it_orig.second;
+      while ( it_begin_orig != it_end_orig ) {
+        if ( it_begin_orig->original_raster != raster )
+          return 1;
+        if ( it_begin_orig->approximate_raster == approximate_raster ) {
+          if ( it_begin_orig->quality == 1.0 )
+            found = true;
+        }
+        it_begin_orig++;
       }
-      it_begin_approx++;
+      if ( !found )
+        return 1;
+
+      found = false;
+      auto it_approx =
+        quality_db.search_by_approximate_raster( approximate_raster );
+      QualityDBCollectionByApproximateRaster::iterator it_begin_approx = it_approx.first;
+      QualityDBCollectionByApproximateRaster::iterator it_end_approx = it_approx.second;
+      while ( it_begin_approx != it_end_approx ) {
+        if ( it_begin_approx->approximate_raster != approximate_raster )
+          return 1;
+        if ( it_begin_approx->original_raster == raster ) {
+          if ( it_begin_approx->quality == 1.0 )
+            found = true;
+        }
+        it_begin_approx++;
+      }
+      if ( !found )
+        return 1;
     }
-    if ( !found )
-      return 1;
 
     // Check frame db
     found = false;

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -4,7 +4,9 @@ AM_CXXFLAGS = $(PICKY_CXXFLAGS) $(NODEBUG_CXXFLAGS)
 noinst_LIBRARIES = libalfalfautil.a
 
 libalfalfautil_a_SOURCES = 2d.hh chunk.hh exception.hh file.cc \
-	filesystem.cc filesystem.hh \
-	file_descriptor.hh file.hh ivf.cc ivf.hh \
-	optional.hh safe_array.hh raster.hh raster.cc ssim.hh ssim.cc \
-	ivf_writer.hh ivf_writer.cc mmap_region.hh mmap_region.cc
+  filesystem.cc filesystem.hh \
+  file_descriptor.hh file.hh ivf.cc ivf.hh \
+  optional.hh safe_array.hh raster.hh raster.cc ssim.hh ssim.cc \
+  ivf_writer.hh ivf_writer.cc mmap_region.hh mmap_region.cc \
+  subprocess.hh subprocess.cc \
+  temp_file.hh temp_file.cc

--- a/src/util/raster.cc
+++ b/src/util/raster.cc
@@ -60,3 +60,16 @@ void BaseRaster::dump( FILE * file ) const
     fwrite( &V().at( 0, row ), (1 + display_width()) / 2, 1, file );
   }
 }
+
+void BaseRaster::dump( int fd ) const
+{
+  for ( unsigned int row = 0; row < display_height(); row++ ) {
+    SystemCall( "write raster", write( fd, &Y().at( 0, row ), display_width() ) );
+  }
+  for ( unsigned int row = 0; row < (1 + display_height()) / 2; row++ ) {
+    SystemCall( "write raster", write( fd, &U().at( 0, row ), (1 + display_width()) / 2 ) );
+  }
+  for ( unsigned int row = 0; row < (1 + display_height()) / 2; row++ ) {
+    SystemCall( "write raster", write( fd, &V().at( 0, row ), (1 + display_width()) / 2 ) );
+  }
+}

--- a/src/util/raster.hh
+++ b/src/util/raster.hh
@@ -59,6 +59,7 @@ public:
 
   void copy_from( const BaseRaster & other );
   void dump( FILE * file ) const;
+  void dump( int fd ) const;
 };
 
 #endif /* RASTER_HH */

--- a/src/util/subprocess.cc
+++ b/src/util/subprocess.cc
@@ -1,0 +1,43 @@
+#include "subprocess.hh"
+#include "exception.hh"
+
+Subprocess::Subprocess()
+{}
+
+void Subprocess::call( const std::string & command, const std::string & type )
+{
+  file_.reset( popen( command.c_str(), type.c_str() ) );
+
+  if ( file_ == nullptr ) {
+    throw unix_error( "popen failed" );
+  }
+}
+
+int Subprocess::wait()
+{
+  if ( file_ == nullptr ) {
+    throw unix_error( "nothing to close" );
+  }
+
+  int ret = SystemCall( "pclose", pclose( file_.get() ) );
+  file_.release();
+
+  return ret;
+}
+
+size_t Subprocess::write_string( const std::string & str )
+{
+  if ( file_ == nullptr ) {
+    throw unix_error( "nowhere to write" );
+  }
+
+  return SystemCall( "fwrite", fwrite( str.c_str(), 1, str.length(), file_.get() ) );
+}
+
+Subprocess::~Subprocess()
+{
+  if ( file_ != nullptr ) {
+    pclose( file_.get() );
+    file_.release();
+  }
+}

--- a/src/util/subprocess.hh
+++ b/src/util/subprocess.hh
@@ -1,0 +1,26 @@
+#ifndef SUBPROCESS_HH
+#define SUBPROCESS_HH
+
+#include <stdio.h>
+#include <string>
+#include <memory>
+
+using namespace std;
+
+class Subprocess
+{
+private:
+  std::unique_ptr<FILE> file_{ nullptr };
+
+public:
+  Subprocess();
+  void call( const string & command, const string & type = "w" );
+
+  size_t write_string( const string & str );
+  FILE * stream() { return file_.get(); }
+
+  int wait();
+  ~Subprocess();
+};
+
+#endif /* SUBPROCESS_HH */

--- a/src/util/system_runner.cc
+++ b/src/util/system_runner.cc
@@ -1,0 +1,51 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <vector>
+#include <cassert>
+#include <unistd.h>
+#include <thread>
+#include <exception>
+
+#include "exception.hh"
+
+using namespace std;
+
+int ezexec( const vector< string > & command, const bool path_search )
+{
+    if ( command.empty() ) {
+        throw runtime_error( "ezexec: empty command" );
+    }
+
+    if ( geteuid() == 0 or getegid() == 0 ) {
+        if ( environ ) {
+            throw runtime_error( "BUG: root's environment not cleared" );
+        }
+
+        if ( path_search ) {
+            throw runtime_error( "BUG: root should not search PATH" );
+        }
+    }
+
+    /* copy the arguments to mutable structures */
+    vector<char *> argv;
+    vector< vector< char > > argv_data;
+
+    for ( auto & x : command ) {
+        vector<char> new_str;
+        for ( auto & ch : x ) {
+            new_str.push_back( ch );
+        }
+        new_str.push_back( 0 ); /* null-terminate */
+
+        argv_data.push_back( new_str );
+    }
+
+    for ( auto & x : argv_data ) {
+        argv.push_back( &x[ 0 ] );
+    }
+    argv.push_back( 0 ); /* null-terminate */
+
+    SystemCall( path_search ? "execvpe" : "execve",
+                (path_search ? execvpe : execve )( &argv[ 0 ][ 0 ], &argv[ 0 ], environ ) );
+    throw runtime_error( "execve: failed" );
+}

--- a/src/util/system_runner.hh
+++ b/src/util/system_runner.hh
@@ -1,0 +1,10 @@
+#ifndef SYSTEM_RUNNER_HH
+#define SYSTEM_RUNNER_HH
+
+#include <vector>
+#include <string>
+#include <functional>
+
+int ezexec( const std::vector< std::string > & command, const bool path_search = false );
+
+#endif /* SYSTEM_RUNNER_HH */

--- a/src/util/temp_file.cc
+++ b/src/util/temp_file.cc
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <cstdlib>
+#include <unistd.h>
+#include <cassert>
+
+#include "temp_file.hh"
+#include "exception.hh"
+
+using namespace std;
+
+vector<char> to_mutable( const string & str )
+{
+  vector< char > ret;
+  for ( const auto & ch : str ) {
+    ret.push_back( ch );
+  }
+  ret.push_back( 0 ); /* null terminate */
+
+  return ret;
+}
+
+UniqueFile::UniqueFile( const string & filename_template )
+  : mutable_temp_filename_( to_mutable( filename_template + ".XXXXXX" ) ),
+   fd_( SystemCall( "mkstemp", mkstemp( &mutable_temp_filename_[ 0 ] ) ) ),
+   moved_away_( false )
+{
+}
+
+/* unlike UniqueFile, a TempFile is deleted when object destroyed */
+TempFile::~TempFile()
+{
+  if ( moved_away_ ) { return; }
+
+  try {
+    SystemCall( "unlink " + name(), unlink( name().c_str() ) );
+  } catch ( const exception & e ) {
+    print_exception( "tempfile", e );
+  }
+}
+
+void UniqueFile::write( const string & contents )
+{
+  assert( not moved_away_ );
+
+  fd_.write( contents );
+}
+
+UniqueFile::UniqueFile( UniqueFile && other )
+  : mutable_temp_filename_( other.mutable_temp_filename_ ),
+   fd_( move( other.fd_ ) ),
+   moved_away_( false )
+{
+  other.moved_away_ = true;
+}
+
+string UniqueFile::name( void ) const
+{
+  assert( mutable_temp_filename_.size() > 1 );
+  return string( mutable_temp_filename_.begin(), mutable_temp_filename_.end() - 1 );
+}

--- a/src/util/temp_file.hh
+++ b/src/util/temp_file.hh
@@ -1,0 +1,51 @@
+#ifndef TEMP_FILE_HH
+#define TEMP_FILE_HH
+
+#include <string>
+#include <vector>
+
+#include "file_descriptor.hh"
+
+class UniqueFile
+{
+private:
+  std::vector<char> mutable_temp_filename_;
+  FileDescriptor fd_;
+
+protected:
+  bool moved_away_;
+
+public:
+  UniqueFile( const std::string & filename_template );
+  virtual ~UniqueFile() {}
+
+  std::string name( void ) const;
+
+  void write( const std::string & contents );
+
+  FileDescriptor & fd( void ) { return fd_; }
+
+  /* ban copying */
+  UniqueFile( const UniqueFile & other ) = delete;
+  UniqueFile & operator=( const UniqueFile & other ) = delete;
+
+  /* allow move constructor */
+  UniqueFile( UniqueFile && other );
+
+  /* ... but not move assignment operator */
+  UniqueFile & operator=( UniqueFile && other ) = delete;
+};
+
+/* TempFile is deleted when object destroyed */
+class TempFile : public UniqueFile
+{
+public:
+  using UniqueFile::UniqueFile;
+
+  /* allow move constructor */
+  TempFile( TempFile && other ) : UniqueFile( std::move( other ) ) {}
+
+  ~TempFile();
+};
+
+#endif


### PR DESCRIPTION
Example: ```./src/frontend/alfalfa-encode video1.alf/ 0 video2.alf --best -v --ivf --q-hist=100 --rate-hist=100 --end-usage=cq --buf-sz=1000000 --auto-alt-ref=1  --cq-level=32 --tune=ssim --kf-max-dist=1000000 --buf-initial-sz=0 --buf-optimal-sz=500000 --lag-in-frames=16 --target-bitrate=50000000```