### PR TITLE
Refactor: serialization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Makefile.in
 /src/frontend/alfalfa-combine
 /src/frontend/alfalfa-describe
 /src/frontend/alfalfa-encode
+/src/frontend/alfalfa-play-super-manually
 /src/tests/decode-to-stdout
 /src/tests/encode-loopback
 /src/tests/extract-key-frames

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ Makefile.in
 /src/tests/import-test
 /src/tests/trackdb-test
 /src/tests/combine-test
+/src/tests/alf-decode-to-stdout
 
 /src/tests/test_vectors/

--- a/src/decoder/dependency_tracking.cc
+++ b/src/decoder/dependency_tracking.cc
@@ -54,11 +54,6 @@ static SourceHash decode_source( const string & frame_name )
                      components.at( 3 ), components.at( 4 ) );
 }
 
-SourceHash::SourceHash()
-  : SourceHash( Optional<size_t>(), Optional<size_t>(), Optional<size_t>(),
-    Optional<size_t>(), Optional<size_t>() )
-{}
-
 SourceHash::SourceHash( const string & frame_name )
   : SourceHash( decode_source( frame_name ) )
 {}
@@ -170,10 +165,6 @@ UpdateTracker::UpdateTracker( bool set_update_last, bool set_update_golden,
     alternate_to_golden( set_alternate_to_golden )
 {}
 
-UpdateTracker::UpdateTracker()
-  : UpdateTracker( false, false, false, false, false, false, false )
-{}
-
 static TargetHash decode_target( const string & frame_name )
 {
   SafeArray<size_t, 11> components;
@@ -206,11 +197,6 @@ TargetHash::TargetHash( const UpdateTracker & updates, size_t state,
     continuation_hash( continuation ),
     output_hash( output ),
     shown( show )
-{}
-
-TargetHash::TargetHash()
-: UpdateTracker(), state_hash( 0 ), continuation_hash( 0 ), output_hash( 0 ),
-  shown( false )
 {}
 
 string TargetHash::str() const

--- a/src/decoder/dependency_tracking.hh
+++ b/src/decoder/dependency_tracking.hh
@@ -28,7 +28,6 @@ public:
   Optional<size_t> state_hash, continuation_hash,
                    last_hash, golden_hash, alt_hash;
 
-  SourceHash();
   SourceHash( const std::string & frame_name );
   SourceHash( const Optional<size_t> & state, const Optional<size_t> & continuation,
               const Optional<size_t> & last, const Optional<size_t> & golden,
@@ -55,7 +54,6 @@ public:
   bool golden_to_alternate;
   bool alternate_to_golden;
 
-  UpdateTracker();
   UpdateTracker( bool set_update_last, bool set_update_golden,
                  bool set_update_alternate, bool set_last_to_golden,
                  bool set_last_to_alternate, bool set_golden_to_alternate,
@@ -75,7 +73,6 @@ public:
   size_t state_hash, continuation_hash, output_hash;
   bool shown;
 
-  TargetHash();
   TargetHash( const std::string & frame_name );
   TargetHash( const UpdateTracker & updates, size_t state,
               size_t continuation, size_t output, bool shown );

--- a/src/decoder/frame_info.cc
+++ b/src/decoder/frame_info.cc
@@ -1,12 +1,9 @@
 #include "frame_info.hh"
 #include "file.hh"
 
-FrameInfo::FrameInfo()
-  : offset_( 0 ), length_( 0 ), index_( 0 ), source_hash_(),
-    target_hash_(), frame_id_( 0 )
-{}
+using namespace std;
 
-FrameInfo::FrameInfo( const std::string & frame_name,
+FrameInfo::FrameInfo( const string & frame_name,
                       const size_t & offset, const size_t & length )
   : offset_( offset ),
     length_( length ),
@@ -41,7 +38,7 @@ bool FrameInfo::shown() const
   return target_hash_.shown;
 }
 
-std::string build_frame_name( const SourceHash & source_hash,
+string build_frame_name( const SourceHash & source_hash,
   const TargetHash & target_hash )
 {
   return source_hash.str() + "#" + target_hash.str();

--- a/src/decoder/frame_info.hh
+++ b/src/decoder/frame_info.hh
@@ -8,8 +8,6 @@
 #include "dependency_tracking.hh"
 #include "serialized_frame.hh"
 
-using namespace std;
-
 std::string build_frame_name( const SourceHash & source_hash,
   const TargetHash & target_hash );
 
@@ -38,8 +36,6 @@ public:
   void set_length( const size_t & length ) { length_ = length; }
   void set_index( const size_t & index ) { index_ = index; }
   void set_frame_id( const size_t & frame_id ) { frame_id_ = frame_id; }
-
-  FrameInfo();
 
   FrameInfo( const std::string & frame_name, const size_t & offset,
              const size_t & length );

--- a/src/decoder/player.cc
+++ b/src/decoder/player.cc
@@ -48,7 +48,7 @@ FilePlayer::FilePlayer( const string & filename )
   : FilePlayer( filename, IVF( filename ) )
 {}
 
-FilePlayer::FilePlayer( const std::string & filename, IVF && file )
+FilePlayer::FilePlayer( const string & filename, IVF && file )
   : FramePlayer( file.width(), file.height() ),
     file_ ( move( file ) ),
     filename_( filename )

--- a/src/decoder/tracking_player.hh
+++ b/src/decoder/tracking_player.hh
@@ -7,12 +7,13 @@ class TrackingPlayer : public FilePlayer
 {
 private:
   template<class FrameType>
-  pair<FrameInfo, Optional<RasterHandle>> decode_and_info( const FrameType & frame, const Decoder & source,
-                                                           const FrameRawData & raw_data );
+  std::pair<FrameInfo, Optional<RasterHandle> > decode_and_info( const FrameType & frame,
+                                                                 const Decoder & source,
+                                                                 const FrameRawData & raw_data );
 
 public:
   using FilePlayer::FilePlayer;
-  pair<FrameInfo, Optional<RasterHandle>> serialize_next();
+  std::pair<FrameInfo, Optional<RasterHandle> > serialize_next();
   RasterHandle next_output();
 };
 

--- a/src/display/display.cc
+++ b/src/display/display.cc
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-const std::string VideoDisplay::shader_source_scale_from_pixel_coordinates
+const string VideoDisplay::shader_source_scale_from_pixel_coordinates
 = R"( #version 130
 
       uniform uvec2 window_size;
@@ -26,7 +26,7 @@ const std::string VideoDisplay::shader_source_scale_from_pixel_coordinates
                       224*[-0.38542789394266 .5 -0.11457210605734]'
                       224*[-0.454152908305817 -0.0458470916941834 .5]']') */
 
-const std::string VideoDisplay::shader_source_ycbcr
+const string VideoDisplay::shader_source_ycbcr
 = R"( #version 130
       #extension GL_ARB_texture_rectangle : enable
 
@@ -101,7 +101,7 @@ VideoDisplay::VideoDisplay( const BaseRaster & raster )
   glCheck( "" );
 }
 
-void VideoDisplay::resize( const std::pair<unsigned int, unsigned int> & target_size )
+void VideoDisplay::resize( const pair<unsigned int, unsigned int> & target_size )
 {
   glViewport( 0, 0, target_size.first, target_size.second );
 

--- a/src/display/display.hh
+++ b/src/display/display.hh
@@ -7,8 +7,6 @@
 #include "raster.hh"
 #include "gl_objects.hh"
 
-using namespace std;
-
 class VideoDisplay
 {
 private:

--- a/src/encoder/encode_tree.cc
+++ b/src/encoder/encode_tree.cc
@@ -2,6 +2,8 @@
 
 #include "bool_encoder.hh"
 
+using namespace std;
+
 template <class enumeration, uint8_t alphabet_size, const TreeArray< alphabet_size > & nodes >
 static void encode( BoolEncoder & encoder,
 		    const Tree< enumeration, alphabet_size, nodes > & value,
@@ -13,7 +15,7 @@ static void encode( BoolEncoder & encoder,
     value_to_index.at( 128 + nodes.at( i ) - 1 ) = i;
   }
 
-  std::vector< std::pair< bool, Probability > > bits;
+  vector< pair< bool, Probability > > bits;
 
   /* find the path to the node */
   uint8_t node_index = value_to_index.at( 128 - value - 1 );

--- a/src/format/alfalfa_video.cc
+++ b/src/format/alfalfa_video.cc
@@ -175,27 +175,21 @@ double AlfalfaVideo::get_quality( int raster_index, const FrameInfo & frame_info
 
 WritableAlfalfaVideo::WritableAlfalfaVideo( const string & directory_name,
                                             const string & fourcc,
-                                            const uint16_t width, const uint16_t height,
-                                            const uint32_t frame_rate_numerator,
-                                            const uint32_t frame_rate_denominator )
+                                            const uint16_t width, const uint16_t height )
   : AlfalfaVideo( directory_name, OpenMode::TRUNCATE ),
-    ivf_writer_( directory_.ivf_filename(), fourcc, width, height,
-      frame_rate_numerator, frame_rate_denominator )
+    ivf_writer_( directory_.ivf_filename(), fourcc, width, height, 24, 1 )
 {
-  video_manifest_.set_info( VideoInfo( fourcc, width, height,
-    frame_rate_numerator, frame_rate_denominator, 0 ) );
+  video_manifest_.set_info( VideoInfo( fourcc, width, height ) );
 }
 
 WritableAlfalfaVideo::WritableAlfalfaVideo( const string & directory_name,
                                             const IVF & ivf )
-  : WritableAlfalfaVideo( directory_name, ivf.fourcc(), ivf.width(), ivf.height(),
-      ivf.frame_rate(), ivf.time_scale() )
+  : WritableAlfalfaVideo( directory_name, ivf.fourcc(), ivf.width(), ivf.height() )
 {}
 
 WritableAlfalfaVideo::WritableAlfalfaVideo( const string & directory_name,
                                             const VideoInfo & info )
-  : WritableAlfalfaVideo( directory_name, info.fourcc, info.width, info.height,
-    info.frame_rate_numerator, info.frame_rate_denominator )
+  : WritableAlfalfaVideo( directory_name, info.fourcc, info.width, info.height )
 {}
 
 void WritableAlfalfaVideo::combine( const PlayableAlfalfaVideo & video )
@@ -419,8 +413,8 @@ void PlayableAlfalfaVideo::encode( const size_t track_id, vector<string> vpxenc_
 
     ostringstream ss;
     ss << "YUV4MPEG2 W" << video_manifest().width() << " "
+      << "F1:1 "
       << "H" << video_manifest().height() << " "
-      << "F" << video_manifest().frame_rate_numerator() << ":" << video_manifest().frame_rate_denominator() << " "
       << "Ip A0:0 C420 C420jpeg XYSCSS=420JPEG\n";
 
     string header( ss.str() );

--- a/src/format/alfalfa_video.cc
+++ b/src/format/alfalfa_video.cc
@@ -15,41 +15,43 @@
 
 #define VPXENC_EXECUTABLE "vpxenc"
 
-AlfalfaVideo::VideoDirectory::VideoDirectory( const std::string & path )
+using namespace std;
+
+AlfalfaVideo::VideoDirectory::VideoDirectory( const string & path )
   : directory_path_( path )
 {}
 
-std::string AlfalfaVideo::VideoDirectory::video_manifest_filename() const
+string AlfalfaVideo::VideoDirectory::video_manifest_filename() const
 {
   return FileSystem::append( directory_path_, VIDEO_MANIFEST_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::raster_list_filename() const
+string AlfalfaVideo::VideoDirectory::raster_list_filename() const
 {
   return FileSystem::append( directory_path_, RASTER_LIST_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::quality_db_filename() const
+string AlfalfaVideo::VideoDirectory::quality_db_filename() const
 {
   return FileSystem::append( directory_path_, QUALITY_DB_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::frame_db_filename() const
+string AlfalfaVideo::VideoDirectory::frame_db_filename() const
 {
   return FileSystem::append( directory_path_, FRAME_DB_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::track_db_filename() const
+string AlfalfaVideo::VideoDirectory::track_db_filename() const
 {
   return FileSystem::append( directory_path_, TRACK_DB_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::switch_db_filename() const
+string AlfalfaVideo::VideoDirectory::switch_db_filename() const
 {
   return FileSystem::append( directory_path_, SWITCH_DB_FILENAME );
 }
 
-std::string AlfalfaVideo::VideoDirectory::ivf_filename() const
+string AlfalfaVideo::VideoDirectory::ivf_filename() const
 {
   return FileSystem::append( directory_path_, IVF_FILENAME );
 }
@@ -98,21 +100,21 @@ bool AlfalfaVideo::can_combine( const AlfalfaVideo & video )
   );
 }
 
-std::pair<std::unordered_set<size_t>::iterator, std::unordered_set<size_t>::iterator>
+pair<unordered_set<size_t>::iterator, unordered_set<size_t>::iterator>
 AlfalfaVideo::get_track_ids()
 {
   return make_pair( track_ids_.begin(), track_ids_.end() );
 }
 
-std::pair<std::unordered_set<size_t>::iterator, std::unordered_set<size_t>::iterator>
+pair<unordered_set<size_t>::iterator, unordered_set<size_t>::iterator>
 AlfalfaVideo::get_track_ids_from_track(const size_t from_track_id, const size_t from_frame_index)
 {
-  std::unordered_set<size_t> to_track_ids = switch_mappings_.at(
+  unordered_set<size_t> to_track_ids = switch_mappings_.at(
     make_pair( from_track_id, from_frame_index ) );
   return make_pair( to_track_ids.begin(), to_track_ids.end() );
 }
 
-std::pair<TrackDBIterator, TrackDBIterator>
+pair<TrackDBIterator, TrackDBIterator>
 AlfalfaVideo::get_frames( const size_t track_id )
 {
   size_t end_frame_index = track_db_.get_end_frame_index( track_id );
@@ -121,7 +123,7 @@ AlfalfaVideo::get_frames( const size_t track_id )
   return make_pair( begin, end );
 }
 
-std::pair<TrackDBIterator, TrackDBIterator>
+pair<TrackDBIterator, TrackDBIterator>
 AlfalfaVideo::get_frames( const TrackDBIterator & it )
 {
   size_t track_id = it.track_id();
@@ -133,7 +135,7 @@ AlfalfaVideo::get_frames( const TrackDBIterator & it )
   return make_pair( begin, end );
 }
 
-std::pair<TrackDBIterator, TrackDBIterator>
+pair<TrackDBIterator, TrackDBIterator>
 AlfalfaVideo::get_frames( const SwitchDBIterator & it )
 {
   size_t track_id = it.to_track_id();
@@ -145,7 +147,7 @@ AlfalfaVideo::get_frames( const SwitchDBIterator & it )
   return make_pair( begin, end );
 }
 
-std::pair<SwitchDBIterator, SwitchDBIterator>
+pair<SwitchDBIterator, SwitchDBIterator>
 AlfalfaVideo::get_frames( const TrackDBIterator & it, const size_t to_track_id )
 {
   size_t from_track_id = it.track_id();
@@ -421,7 +423,7 @@ void PlayableAlfalfaVideo::encode( const size_t track_id, vector<string> vpxenc_
       << "F" << video_manifest().frame_rate_numerator() << ":" << video_manifest().frame_rate_denominator() << " "
       << "Ip A0:0 C420 C420jpeg XYSCSS=420JPEG\n";
 
-    std::string header( ss.str() );
+    string header( ss.str() );
     proc.write_string( header );
 
     for( auto track_frames = get_frames( track_id ); track_frames.first != track_frames.second; track_frames.first++ ) {

--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -122,11 +122,11 @@ private:
   File ivf_file_;
 
 public:
-  PlayableAlfalfaVideo( const string & directory_name );
+  PlayableAlfalfaVideo( const std::string & directory_name );
 
   const Chunk get_chunk( const FrameInfo & frame_info ) const;
-  void encode( const size_t track_id, vector<string> vpxenc_args,
-               const string & destination );
+  void encode( const size_t track_id, std::vector<std::string> vpxenc_args,
+               const std::string & destination );
 };
 
 class WritableAlfalfaVideo : public AlfalfaVideo
@@ -138,14 +138,14 @@ private:
                      const size_t original_raster, const double quality,
                      size_t & frame_id, size_t & frame_index, const size_t track_id );
 
-  void write_ivf( const string & filename );
+  void write_ivf( const std::string & filename );
 
 public:
-  WritableAlfalfaVideo( const string & directory_name,
-                        const string & fourcc, const uint16_t width, const uint16_t height,
+  WritableAlfalfaVideo( const std::string & directory_name,
+                        const std::string & fourcc, const uint16_t width, const uint16_t height,
                         const uint32_t frame_rate_numerator, const uint32_t frame_rate_denominator );
-  WritableAlfalfaVideo( const string & directory_name, const IVF & ivf );
-  WritableAlfalfaVideo( const string & directory_name, const VideoInfo & info );
+  WritableAlfalfaVideo( const std::string & directory_name, const IVF & ivf );
+  WritableAlfalfaVideo( const std::string & directory_name, const VideoInfo & info );
 
   void combine( const PlayableAlfalfaVideo & video );
   void import( const std::string & filename );

--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -142,8 +142,7 @@ private:
 
 public:
   WritableAlfalfaVideo( const std::string & directory_name,
-                        const std::string & fourcc, const uint16_t width, const uint16_t height,
-                        const uint32_t frame_rate_numerator, const uint32_t frame_rate_denominator );
+                        const std::string & fourcc, const uint16_t width, const uint16_t height );
   WritableAlfalfaVideo( const std::string & directory_name, const IVF & ivf );
   WritableAlfalfaVideo( const std::string & directory_name, const VideoInfo & info );
 

--- a/src/format/db.cc
+++ b/src/format/db.cc
@@ -1,10 +1,12 @@
 #include "db.hh"
 
-SerializableData::SerializableData( const std::string & filename, const std::string & magic_number,
+using namespace std;
+
+SerializableData::SerializableData( const string & filename, const string & magic_number,
   OpenMode mode )
     : filename_( filename ), mode_ ( mode ), good_( false ), magic_number( magic_number )
 {
-  std::ifstream fin( filename );
+  ifstream fin( filename );
 
   switch( mode_ ) {
   case OpenMode::READ:

--- a/src/format/db.hh
+++ b/src/format/db.hh
@@ -119,8 +119,7 @@ bool BasicDatabase<RecordType, RecordProtobufType, Collection, SequencedTag>
 
   // Writing entries
   for ( const RecordType & it : collection_.get<SequencedTag>() ) {
-    RecordProtobufType message;
-    to_protobuf( it, message );
+    RecordProtobufType message = to_protobuf( it );
 
     if ( not serializer.write_protobuf( message ) ) {
       return false;
@@ -147,8 +146,7 @@ bool BasicDatabase<RecordType, RecordProtobufType, Collection, SequencedTag>
   RecordProtobufType message;
 
   while ( deserializer.read_protobuf( message ) ) {
-    RecordType record;
-    from_protobuf( message, record );
+    RecordType record = from_protobuf( message );
     insert( record );
   }
 

--- a/src/format/frame_db.cc
+++ b/src/format/frame_db.cc
@@ -5,7 +5,9 @@
 #include "serialization.hh"
 #include "protobufs/alfalfa.pb.h"
 
-std::pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator>
+using namespace std;
+
+pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator>
 FrameDB::search_by_output_hash( const size_t & output_hash )
 {
   FrameDataSetCollectionByOutputHash & data_by_output_hash =
@@ -13,7 +15,7 @@ FrameDB::search_by_output_hash( const size_t & output_hash )
   return data_by_output_hash.equal_range( output_hash );
 }
 
-std::pair<FrameDataSetSourceHashSearch::iterator, FrameDataSetSourceHashSearch::iterator>
+pair<FrameDataSetSourceHashSearch::iterator, FrameDataSetSourceHashSearch::iterator>
 FrameDB::search_by_decoder_hash( const DecoderHash & decoder_hash )
 {
   SourceHash query_hash(
@@ -50,7 +52,7 @@ FrameDB::search_by_frame_id( const size_t & frame_id )
 {
   FrameDataSetCollectionById & index = collection_.get<FrameDataSetByIdTag>();
   if ( index.count( frame_id ) == 0 )
-    throw std::out_of_range( "Invalid frame_id!" );
+    throw out_of_range( "Invalid frame_id!" );
   FrameDataSetCollectionById::iterator id_iterator =
     index.find( frame_id );
   return *id_iterator;
@@ -62,7 +64,7 @@ FrameDB::search_by_frame_name( const SourceHash & source_hash, const TargetHash 
   FrameDataSetCollectionByFrameName & index = collection_.get<FrameDataSetByFrameNameTag>();
   auto key = boost::make_tuple( source_hash, target_hash );
   if ( index.count( key ) == 0 )
-    throw std::out_of_range( "Invalid (source_hash, target_hash) pair" );
+    throw out_of_range( "Invalid (source_hash, target_hash) pair" );
   FrameDataSetCollectionByFrameName::iterator name_iterator = index.find( key );
   return *name_iterator;
 }

--- a/src/format/frame_db.hh
+++ b/src/format/frame_db.hh
@@ -24,7 +24,6 @@
 #include "ivf_writer.hh"
 #include "filesystem.hh"
 
-using namespace std;
 using namespace boost::multi_index;
 using boost::multi_index_container;
 
@@ -197,7 +196,8 @@ public:
   const FrameInfo & search_by_frame_name( const SourceHash & source_hash, const TargetHash & target_hash );
 
   void
-  merge( const FrameDB & db, map<size_t, size_t> & frame_id_mapping, IVFWriter & combined_ivf_writer, const string & ivf_file_path );
+  merge( const FrameDB & db, std::map<size_t, size_t> & frame_id_mapping,
+         IVFWriter & combined_ivf_writer, const std::string & ivf_file_path );
 
 };
 

--- a/src/format/manifests.cc
+++ b/src/format/manifests.cc
@@ -16,9 +16,6 @@ void VideoManifest::set_info( const VideoInfo & info )
   info_.fourcc = info.fourcc;
   info_.width = info.width;
   info_.height = info.height;
-  info_.frame_rate_numerator = info.frame_rate_numerator;
-  info_.frame_rate_denominator = info.frame_rate_denominator;
-  info_.frame_count = info.frame_count;
 }
 
 bool VideoManifest::deserialize()

--- a/src/format/manifests.cc
+++ b/src/format/manifests.cc
@@ -121,6 +121,23 @@ TrackDB::search_by_track_id( const size_t & track_id )
   return index.equal_range( track_id );
 }
 
+std::unordered_set<size_t>*
+TrackDB::track_ids()
+{
+  std::unordered_set<size_t> *track_ids = new std::unordered_set<size_t>();
+  TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
+  TrackDBCollectionByTrackIdAndFrameIndex::iterator beg = index.begin();
+  TrackDBCollectionByTrackIdAndFrameIndex::iterator end = index.end();
+  while(beg != end)
+  {
+    TrackData track_data = *beg;
+    (*track_ids).insert( track_data.track_id );
+    beg++;
+  }
+  return track_ids;
+}
+
+
 bool TrackDB::has_track( const size_t & track_id ) const
 {
   const TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();

--- a/src/format/manifests.cc
+++ b/src/format/manifests.cc
@@ -118,22 +118,23 @@ TrackDB::search_by_track_id( const size_t & track_id )
   return index.equal_range( track_id );
 }
 
-std::unordered_set<size_t>*
-TrackDB::track_ids()
+std::unordered_set<size_t> TrackDB::track_ids()
 {
-  std::unordered_set<size_t> *track_ids = new std::unordered_set<size_t>();
+  std::unordered_set<size_t> track_ids;
+
   TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
   TrackDBCollectionByTrackIdAndFrameIndex::iterator beg = index.begin();
   TrackDBCollectionByTrackIdAndFrameIndex::iterator end = index.end();
+
   while(beg != end)
   {
     TrackData track_data = *beg;
-    (*track_ids).insert( track_data.track_id );
+    track_ids.insert( track_data.track_id );
     beg++;
   }
+
   return track_ids;
 }
-
 
 bool TrackDB::has_track( const size_t & track_id ) const
 {

--- a/src/format/manifests.cc
+++ b/src/format/manifests.cc
@@ -1,6 +1,8 @@
 #include "manifests.hh"
 
-VideoManifest::VideoManifest( const std::string & filename, const std::string & magic_number,
+using namespace std;
+
+VideoManifest::VideoManifest( const string & filename, const string & magic_number,
   OpenMode mode )
     : SerializableData( filename, magic_number, mode ), info_()
 {
@@ -29,7 +31,7 @@ bool VideoManifest::deserialize()
 
   AlfalfaProtobufs::VideoInfo message;
   deserializer.read_protobuf( message );
-  from_protobuf( message, info_ );
+  info_ = from_protobuf( message );
   return true;
 }
 
@@ -44,10 +46,8 @@ bool VideoManifest::serialize() const
   // Writing the header
   serializer.write_string( magic_number );
 
-  AlfalfaProtobufs::VideoInfo message;
-  to_protobuf( info_, message );
-  bool result = serializer.write_protobuf( message );
-  return result;
+  AlfalfaProtobufs::VideoInfo message = to_protobuf( info_ );
+  return serializer.write_protobuf( message );
 }
 
 bool RasterList::has( const size_t & raster_hash ) const
@@ -60,7 +60,7 @@ size_t RasterList::raster( size_t raster_index )
 {
   const RasterListCollectionRandomAccess & data_by_random_access = collection_.get<RasterListRandomAccessTag>();
   if ( data_by_random_access.size() <= raster_index )
-    throw std::out_of_range( "Invalid raster index!" );
+    throw out_of_range( "Invalid raster index!" );
   return data_by_random_access.at( raster_index ).hash;
 }
 
@@ -92,27 +92,27 @@ QualityDB::search_by_original_and_approximate_raster( const size_t & original_ra
     collection_.get<QualityDBByOriginalAndApproximateRasterTag>();
   auto key = boost::make_tuple( original_raster, approximate_raster );
   if ( index.count( key ) == 0 )
-    throw std::out_of_range( "Raster pair not found!" );
+    throw out_of_range( "Raster pair not found!" );
   QualityDBCollectionByOriginalAndApproximateRaster::iterator it =
     index.find( key );
   return *it;
 }
 
-std::pair<QualityDBCollectionByOriginalRaster::iterator, QualityDBCollectionByOriginalRaster::iterator>
+pair<QualityDBCollectionByOriginalRaster::iterator, QualityDBCollectionByOriginalRaster::iterator>
 QualityDB::search_by_original_raster( const size_t & original_raster )
 {
   QualityDBCollectionByOriginalRaster & index = collection_.get<QualityDBByOriginalRasterTag>();
   return index.equal_range( original_raster );
 }
 
-std::pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator>
+pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator>
 QualityDB::search_by_approximate_raster( const size_t & approximate_raster )
 {
   QualityDBCollectionByApproximateRaster & index = collection_.get<QualityDBByApproximateRasterTag>();
   return index.equal_range( approximate_raster );
 }
 
-std::pair<TrackDBCollectionByTrackIdAndFrameIndex::iterator, TrackDBCollectionByTrackIdAndFrameIndex::iterator>
+pair<TrackDBCollectionByTrackIdAndFrameIndex::iterator, TrackDBCollectionByTrackIdAndFrameIndex::iterator>
 TrackDB::search_by_track_id( const size_t & track_id )
 {
   TrackDBCollectionByTrackIdAndFrameIndex & index = collection_.get<TrackDBByTrackIdAndFrameIndexTag>();
@@ -158,7 +158,7 @@ TrackDB::get_frame( const size_t & track_id, const size_t & frame_index )
   boost::tuple<size_t, size_t> ordered_key =
     boost::make_tuple( track_id, frame_index );
   if ( ordered_index.count( ordered_key ) == 0 )
-    throw std::out_of_range( "Invalid (track_id, frame_index) pair" );
+    throw out_of_range( "Invalid (track_id, frame_index) pair" );
   TrackDBCollectionByTrackIdAndFrameIndex::iterator ids_iterator = ordered_index.find(
     ordered_key);
   return *ids_iterator;
@@ -265,7 +265,7 @@ SwitchDB::get_frame( const size_t & from_track_id, const size_t & to_track_id,
   boost::tuple<size_t, size_t, size_t, size_t> ordered_key =
     boost::make_tuple( from_track_id, to_track_id, from_frame_index, switch_frame_index );
   if ( ordered_index.count( ordered_key ) == 0 )
-    throw std::out_of_range( "Frame not found in switch DB" );
+    throw out_of_range( "Frame not found in switch DB" );
   SwitchDBCollectionOrderedByTrackIdsAndFrameIndices::iterator ids_iterator = ordered_index.find(
     ordered_key);
   return *ids_iterator;

--- a/src/format/manifests.hh
+++ b/src/format/manifests.hh
@@ -29,10 +29,6 @@ public:
   const std::string & fourcc( void ) const { return info_.fourcc; }
   uint16_t width( void ) const { return info_.width; }
   uint16_t height( void ) const { return info_.height; }
-  double frame_rate( void ) const { return info_.frame_rate(); }
-  uint32_t frame_count( void ) const { return info_.frame_count; }
-  double frame_rate_numerator( void ) const { return info_.frame_rate_numerator; }
-  double frame_rate_denominator( void ) const { return info_.frame_rate_denominator; }
 
   const VideoInfo & info() const { return info_; }
   void set_info( const VideoInfo & info );

--- a/src/format/manifests.hh
+++ b/src/format/manifests.hh
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "db.hh"
 #include "frame_db.hh"
@@ -209,6 +210,7 @@ public:
   const TrackData &
   get_frame( const size_t & track_id, const size_t & frame_index );
   void merge( const TrackDB & db, map<size_t, size_t> & frame_id_mapping );
+  std::unordered_set<size_t>* track_ids();
 };
 
 /*

--- a/src/format/manifests.hh
+++ b/src/format/manifests.hh
@@ -209,7 +209,7 @@ public:
   bool has_track( const size_t & track_id ) const;
   const TrackData &
   get_frame( const size_t & track_id, const size_t & frame_index );
-  void merge( const TrackDB & db, map<size_t, size_t> & frame_id_mapping );
+  void merge( const TrackDB & db, std::map<size_t, size_t> & frame_id_mapping );
   std::unordered_set<size_t>* track_ids();
 };
 

--- a/src/format/manifests.hh
+++ b/src/format/manifests.hh
@@ -206,7 +206,7 @@ public:
   const TrackData &
   get_frame( const size_t & track_id, const size_t & frame_index );
   void merge( const TrackDB & db, std::map<size_t, size_t> & frame_id_mapping );
-  std::unordered_set<size_t>* track_ids();
+  std::unordered_set<size_t> track_ids();
 };
 
 /*

--- a/src/format/protobufs/alfalfa.proto
+++ b/src/format/protobufs/alfalfa.proto
@@ -4,9 +4,6 @@ message VideoInfo {
   required string fourcc = 1;
   required uint32 width = 2;
   required uint32 height = 3;
-  required uint32 frame_rate_numerator = 4;
-  required uint32 frame_rate_denominator = 5;
-  required uint32 frame_count = 6;
 }
 
 message SourceHash {

--- a/src/format/serialization.cc
+++ b/src/format/serialization.cc
@@ -2,29 +2,40 @@
 
 #include "serialization.hh"
 
-void to_protobuf( const VideoInfo & info, AlfalfaProtobufs::VideoInfo & message )
+using namespace std;
+
+AlfalfaProtobufs::VideoInfo to_protobuf( const VideoInfo & info )
 {
+  AlfalfaProtobufs::VideoInfo message;
+
   message.set_fourcc( info.fourcc );
   message.set_width( info.width );
   message.set_height( info.height );
   message.set_frame_rate_numerator( info.frame_rate_numerator );
   message.set_frame_rate_denominator( info.frame_rate_denominator );
   message.set_frame_count( info.frame_count );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::VideoInfo & message, VideoInfo & info )
+VideoInfo from_protobuf( const AlfalfaProtobufs::VideoInfo & message )
 {
+  VideoInfo info;
+
   info.fourcc = message.fourcc();
   info.width = message.width();
   info.height = message.height();
   info.frame_rate_numerator = message.frame_rate_numerator();
   info.frame_rate_denominator = message.frame_rate_denominator();
   info.frame_count = message.frame_count();
+
+  return info;
 }
 
-void to_protobuf( const SourceHash & source_hash,
-  AlfalfaProtobufs::SourceHash & message )
+AlfalfaProtobufs::SourceHash to_protobuf( const SourceHash & source_hash )
 {
+  AlfalfaProtobufs::SourceHash message;
+
   if ( source_hash.state_hash.initialized() ) {
     message.set_state_hash( source_hash.state_hash.get() );
   }
@@ -59,26 +70,25 @@ void to_protobuf( const SourceHash & source_hash,
   else {
     message.clear_alt_hash();
   }
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::SourceHash & message,
-  SourceHash & source_hash )
+SourceHash from_protobuf( const AlfalfaProtobufs::SourceHash & message )
 {
-  source_hash.state_hash = make_optional( message.has_state_hash(),
-    message.state_hash() );
-  source_hash.continuation_hash = make_optional( message.has_continuation_hash(),
-    message.continuation_hash() );
-  source_hash.last_hash = make_optional( message.has_last_hash(),
-    message.last_hash() );
-  source_hash.golden_hash = make_optional( message.has_golden_hash(),
-    message.golden_hash() );
-  source_hash.alt_hash = make_optional( message.has_alt_hash(),
-    message.alt_hash() );
+  return SourceHash(
+    make_optional( message.has_state_hash(), message.state_hash() ),
+    make_optional( message.has_continuation_hash(), message.continuation_hash() ),
+    make_optional( message.has_last_hash(), message.last_hash() ),
+    make_optional( message.has_golden_hash(), message.golden_hash() ),
+    make_optional( message.has_alt_hash(), message.alt_hash() )
+  );
 }
 
-void to_protobuf( const TargetHash & target_hash,
-  AlfalfaProtobufs::TargetHash & message )
+AlfalfaProtobufs::TargetHash to_protobuf( const TargetHash & target_hash )
 {
+  AlfalfaProtobufs::TargetHash message;
+
   message.set_state_hash( target_hash.state_hash );
   message.set_continuation_hash( target_hash.continuation_hash );
   message.set_output_hash( target_hash.output_hash );
@@ -90,134 +100,151 @@ void to_protobuf( const TargetHash & target_hash,
   message.set_golden_to_alternate( target_hash.golden_to_alternate );
   message.set_alternate_to_golden( target_hash.alternate_to_golden );
   message.set_shown( target_hash.shown );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::TargetHash & message,
-  TargetHash & target_hash )
+TargetHash from_protobuf( const AlfalfaProtobufs::TargetHash & message )
 {
-  target_hash.update_last = message.update_last();
-  target_hash.update_golden = message.update_golden();
-  target_hash.update_alternate = message.update_alternate();
-  target_hash.last_to_golden = message.last_to_golden();
-  target_hash.last_to_alternate = message.last_to_alternate();
-  target_hash.golden_to_alternate = message.golden_to_alternate();
-  target_hash.alternate_to_golden = message.alternate_to_golden();
+  UpdateTracker update_tracker(
+    message.update_last(), message.update_golden(), message.update_alternate(),
+    message.last_to_golden(), message.last_to_alternate(),
+    message.golden_to_alternate(), message.alternate_to_golden()
+  );
 
-  target_hash.state_hash = message.state_hash();
-  target_hash.continuation_hash = message.continuation_hash();
-  target_hash.output_hash = message.output_hash();
-  target_hash.shown = message.shown();
+  return TargetHash(
+    update_tracker, message.state_hash(), message.continuation_hash(),
+    message.output_hash(), message.shown()
+  );
 }
 
-void to_protobuf( const RasterData & rd, AlfalfaProtobufs::RasterData & item )
+AlfalfaProtobufs::RasterData to_protobuf( const RasterData & rd )
 {
+  AlfalfaProtobufs::RasterData item;
   item.set_hash( rd.hash );
+  return item;
 }
 
-void from_protobuf( const AlfalfaProtobufs::RasterData & item, RasterData & rd )
+RasterData from_protobuf( const AlfalfaProtobufs::RasterData & item )
 {
-  rd.hash = item.hash();
+  return RasterData{ item.hash() };
 }
 
-void to_protobuf( const QualityData & qd,
-  AlfalfaProtobufs::QualityData & message )
+AlfalfaProtobufs::QualityData to_protobuf( const QualityData & qd )
 {
+  AlfalfaProtobufs::QualityData message;
+
   message.set_original_raster( qd.original_raster );
   message.set_approximate_raster( qd.approximate_raster );
   message.set_quality( qd.quality );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::QualityData & message,
-  QualityData & qd )
+QualityData from_protobuf( const AlfalfaProtobufs::QualityData & message )
 {
+  QualityData qd;
+
   qd.original_raster = message.original_raster();
   qd.approximate_raster = message.approximate_raster();
   qd.quality = message.quality();
+
+  return qd;
 }
 
-void to_protobuf( const TrackData & td,
-  AlfalfaProtobufs::TrackData & message ) {
+AlfalfaProtobufs::TrackData to_protobuf( const TrackData & td )
+{
+  AlfalfaProtobufs::TrackData message;
+
   message.set_track_id( td.track_id );
   message.set_frame_index( td.frame_index );
   message.set_frame_id( td.frame_id );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::TrackData & message,
-  TrackData & td )
+TrackData from_protobuf( const AlfalfaProtobufs::TrackData & message )
 {
-  td.track_id = message.track_id();
-  td.frame_index = message.frame_index();
-  td.frame_id = message.frame_id();
+  return TrackData{
+    message.track_id(),
+    message.frame_index(),
+    message.frame_id()
+  };
 }
 
-void to_protobuf( const FrameInfo & fi, AlfalfaProtobufs::FrameInfo & message )
+AlfalfaProtobufs::FrameInfo to_protobuf( const FrameInfo & fi )
 {
+  AlfalfaProtobufs::FrameInfo message;
+
   message.set_offset( fi.offset() );
   message.set_length( fi.length() );
 
-  to_protobuf( fi.source_hash(), *message.mutable_source_hash() );
-  to_protobuf( fi.target_hash(), *message.mutable_target_hash() );
+  *message.mutable_source_hash() = to_protobuf( fi.source_hash() );
+  *message.mutable_target_hash() = to_protobuf( fi.target_hash() );
 
   message.set_frame_id( fi.frame_id() );
   message.set_index( fi.index() );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::FrameInfo & pfi, FrameInfo & fi )
+FrameInfo from_protobuf( const AlfalfaProtobufs::FrameInfo & pfi )
 {
-  SourceHash source_hash;
-  TargetHash target_hash;
+  SourceHash source_hash = from_protobuf( pfi.source_hash() );
+  TargetHash target_hash = from_protobuf( pfi.target_hash() );
 
-  from_protobuf( pfi.source_hash(), source_hash );
-  from_protobuf( pfi.target_hash(), target_hash );
+  FrameInfo fi(
+    size_t( pfi.offset() ), size_t( pfi.length() ), source_hash, target_hash
+  );
 
-  fi.set_source_hash( source_hash );
-  fi.set_target_hash( target_hash );
-  fi.set_offset( size_t( pfi.offset() ) );
-  fi.set_length( size_t( pfi.length() ) );
   fi.set_frame_id( size_t( pfi.frame_id() ) );
   fi.set_index( size_t( pfi.index() ) );
+
+  return fi;
 }
 
-void to_protobuf( const SwitchData &sd, AlfalfaProtobufs::SwitchData & message )
+AlfalfaProtobufs::SwitchData to_protobuf( const SwitchData & sd )
 {
+  AlfalfaProtobufs::SwitchData message;
+
   message.set_from_track_id( sd.from_track_id );
   message.set_from_frame_index( sd.from_frame_index );
   message.set_to_track_id( sd.to_track_id );
   message.set_to_frame_index( sd.to_frame_index );
   message.set_frame_id( sd.frame_id );
   message.set_switch_frame_index( sd.switch_frame_index );
+
+  return message;
 }
 
-void from_protobuf( const AlfalfaProtobufs::SwitchData &psd, SwitchData & sd )
+SwitchData from_protobuf( const AlfalfaProtobufs::SwitchData & psd )
 {
-  sd.from_track_id = psd.from_track_id();
-  sd.from_frame_index = psd.from_frame_index();
-  sd.to_track_id = psd.to_track_id();
-  sd.to_frame_index = psd.to_frame_index();
-  sd.frame_id = psd.frame_id();
-  sd.switch_frame_index = psd.switch_frame_index();
+  return SwitchData{
+    psd.from_track_id(), psd.from_frame_index(), psd.to_track_id(),
+    psd.to_frame_index(), psd.frame_id(), psd.switch_frame_index()
+  };
 }
 
-ProtobufSerializer::ProtobufSerializer( const std::string & filename )
+ProtobufSerializer::ProtobufSerializer( const string & filename )
   : fout_( SystemCall( filename,
 		       open( filename.c_str(),
 			     O_WRONLY | O_CREAT | O_EXCL,
 			     S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH ) ) )
 {}
 
-void ProtobufSerializer::write_string( const std::string & str )
+void ProtobufSerializer::write_string( const string & str )
 {
   coded_output_.WriteRaw( str.data(), str.size() );
 }
 
-ProtobufDeserializer::ProtobufDeserializer( const std::string & filename )
+ProtobufDeserializer::ProtobufDeserializer( const string & filename )
   : fin_( SystemCall( filename,
 		      open( filename.c_str(), O_RDONLY, 0 ) ) )
 {}
 
-std::string ProtobufDeserializer::read_string( const size_t size )
+string ProtobufDeserializer::read_string( const size_t size )
 {
-  std::string ret;
+  string ret;
   if ( not coded_input_.ReadString( &ret, size ) ) {
     throw runtime_error( "ReadString returned false" );
   }

--- a/src/format/serialization.cc
+++ b/src/format/serialization.cc
@@ -11,9 +11,6 @@ AlfalfaProtobufs::VideoInfo to_protobuf( const VideoInfo & info )
   message.set_fourcc( info.fourcc );
   message.set_width( info.width );
   message.set_height( info.height );
-  message.set_frame_rate_numerator( info.frame_rate_numerator );
-  message.set_frame_rate_denominator( info.frame_rate_denominator );
-  message.set_frame_count( info.frame_count );
 
   return message;
 }
@@ -25,9 +22,6 @@ VideoInfo from_protobuf( const AlfalfaProtobufs::VideoInfo & message )
   info.fourcc = message.fourcc();
   info.width = message.width();
   info.height = message.height();
-  info.frame_rate_numerator = message.frame_rate_numerator();
-  info.frame_rate_denominator = message.frame_rate_denominator();
-  info.frame_count = message.frame_count();
 
   return info;
 }

--- a/src/format/serialization.hh
+++ b/src/format/serialization.hh
@@ -107,22 +107,23 @@ struct SwitchData
   {}
 };
 
-void to_protobuf( const VideoInfo & info, AlfalfaProtobufs::VideoInfo & message );
-void from_protobuf( const AlfalfaProtobufs::VideoInfo & message, VideoInfo & info );
-void to_protobuf( const SourceHash & source_hash, AlfalfaProtobufs::SourceHash & message );
-void from_protobuf( const AlfalfaProtobufs::SourceHash & message, SourceHash & source_hash );
-void to_protobuf( const TargetHash & target_hash, AlfalfaProtobufs::TargetHash & message );
-void from_protobuf( const AlfalfaProtobufs::TargetHash & message, TargetHash & target_hash );
-void to_protobuf( const RasterData & rd, AlfalfaProtobufs::RasterData & item );
-void from_protobuf( const AlfalfaProtobufs::RasterData & item, RasterData & rd );
-void to_protobuf( const QualityData & qd, AlfalfaProtobufs::QualityData & message );
-void from_protobuf( const AlfalfaProtobufs::QualityData & message, QualityData & qd );
-void to_protobuf( const TrackData & td, AlfalfaProtobufs::TrackData & message );
-void from_protobuf( const AlfalfaProtobufs::TrackData & message, TrackData & td );
-void to_protobuf( const FrameInfo & fi, AlfalfaProtobufs::FrameInfo & message );
-void from_protobuf( const AlfalfaProtobufs::FrameInfo & pfi, FrameInfo & fi );
-void to_protobuf( const SwitchData &sd, AlfalfaProtobufs::SwitchData & message );
-void from_protobuf( const AlfalfaProtobufs::SwitchData &pwd, SwitchData & sd );
+AlfalfaProtobufs::VideoInfo   to_protobuf( const VideoInfo & info );
+AlfalfaProtobufs::SourceHash  to_protobuf( const SourceHash & source_hash );
+AlfalfaProtobufs::TargetHash  to_protobuf( const TargetHash & target_hash );
+AlfalfaProtobufs::RasterData  to_protobuf( const RasterData & rd );
+AlfalfaProtobufs::QualityData to_protobuf( const QualityData & qd );
+AlfalfaProtobufs::TrackData   to_protobuf( const TrackData & td );
+AlfalfaProtobufs::FrameInfo   to_protobuf( const FrameInfo & fi );
+AlfalfaProtobufs::SwitchData  to_protobuf( const SwitchData &sd );
+
+VideoInfo   from_protobuf( const AlfalfaProtobufs::VideoInfo & message );
+SourceHash  from_protobuf( const AlfalfaProtobufs::SourceHash & message );
+TargetHash  from_protobuf( const AlfalfaProtobufs::TargetHash & message );
+RasterData  from_protobuf( const AlfalfaProtobufs::RasterData & item );
+QualityData from_protobuf( const AlfalfaProtobufs::QualityData & message );
+TrackData   from_protobuf( const AlfalfaProtobufs::TrackData & message );
+FrameInfo   from_protobuf( const AlfalfaProtobufs::FrameInfo & pfi );
+SwitchData  from_protobuf( const AlfalfaProtobufs::SwitchData &pwd );
 
 // end of protobuf converters
 

--- a/src/format/serialization.hh
+++ b/src/format/serialization.hh
@@ -16,33 +16,21 @@ struct VideoInfo
   std::string fourcc;
   uint16_t width;
   uint16_t height;
-  uint32_t frame_rate_numerator;
-  uint32_t frame_rate_denominator;
-  uint32_t frame_count;
 
   VideoInfo()
-    : fourcc( "VP80" ), width( 0 ), height( 0 ), frame_rate_numerator( 0 ), frame_rate_denominator( 1 ),
-      frame_count( 0 )
+    : fourcc( "VP80" ), width( 0 ), height( 0 )
   {}
 
-  VideoInfo( std::string fourcc, uint16_t width, uint16_t height, uint32_t frame_rate_numerator,
-    uint32_t frame_rate_denominator, uint32_t frame_count )
-    : fourcc( fourcc ), width( width ), height( height ), frame_rate_numerator( frame_rate_numerator ),
-      frame_rate_denominator( frame_rate_denominator ), frame_count( frame_count )
+  VideoInfo( std::string fourcc, uint16_t width, uint16_t height )
+    : fourcc( fourcc ), width( width ), height( height )
   {}
-
-  double frame_rate() const
-  {
-      return (double)frame_rate_numerator / frame_rate_denominator;
-  }
 
   bool operator==( const VideoInfo & other ) const
   {
     return ( fourcc == other.fourcc and
       width == other.width and
-      height == other.height and
-      frame_rate_numerator == other.frame_rate_numerator and
-      frame_rate_denominator == other.frame_rate_denominator );
+      height == other.height
+    );
   }
 
   bool operator!=( const VideoInfo & other ) const

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(srcdir)/../util -I$(srcdir)/../decoder -I$(srcdir)/../format -I$(srcdir)/../display -I$(srcdir)/../encoder -I../format $(GLU_CFLAGS) $(GLEW_CFLAGS) $(GLFW3_CFLAGS) $(X264_CFLAGS) $(CXX11_FLAGS)
 AM_CXXFLAGS = $(PICKY_CXXFLAGS) $(NODEBUG_CXXFLAGS)
 
-bin_PROGRAMS = vp8decode vp8play collisions alfalfa-import alfalfa-combine alfalfa-describe alfalfa-encode
+bin_PROGRAMS = vp8decode vp8play collisions alfalfa-import alfalfa-combine alfalfa-describe alfalfa-encode alfalfa-play-super-manually
 
 vp8decode_SOURCES = vp8decode.cc
 vp8decode_LDADD = ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../display/libalfalfadisplay.a ../util/libalfalfautil.a $(X264_LIBS)
@@ -24,3 +24,6 @@ alfalfa_describe_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfa
 
 alfalfa_encode_SOURCES = alfalfa-encode.cc
 alfalfa_encode_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../util/libalfalfautil.a $(X264_LIBS) $(PROTOBUF_LIBS)
+
+alfalfa_play_super_manually_SOURCES = alfalfa-play-super-manually.cc
+alfalfa_play_super_manually_LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../display/libalfalfadisplay.a ../util/libalfalfautil.a $(GLU_LIBS) $(X264_LIBS) $(GLEW_LIBS) $(GLFW3_LIBS) $(PROTOBUF_LIBS)

--- a/src/frontend/alfalfa-describe.cc
+++ b/src/frontend/alfalfa-describe.cc
@@ -29,74 +29,76 @@ int main( int argc, char const *argv[] )
     return EX_USAGE;
   }
 
-  //Get path to alfalfa video and form alfalfa object
-  string alf_path{ FileSystem::get_realpath( argv[ 1 ] ) };
-  AlfalfaVideo alf( alf_path, OpenMode::READ );
-
-  //Throw expection if the directory does not contain a valid alfalfa video
-  if ( not alf.good() ) {
-    cerr << "'" << alf_path << "' is not a valid Alfalfa video." << endl;
-    return EX_DATAERR;
-  }
+  string alf_path( argv[ 1 ] );
+  PlayableAlfalfaVideo alf( alf_path );
 
   //Get databases from alfalfa video
   QualityDB quality_db = alf.quality_db();
   TrackDB track_db = alf.track_db();
   FrameDB frame_db = alf.frame_db();
 
-  //Calculate frame rate
-  double frame_rate = alf.video_manifest().frame_rate();
+  //Get an iterator to the beginning and end of an unordered set of track ids
+  unordered_set<size_t> track_ids = *track_db.track_ids();
 
-  //Get an iterator to the beginning and end of track 0 (currently cannot iterate through tracks)
-  pair<TrackDBCollectionByTrackIdAndFrameIndex::iterator, TrackDBCollectionByTrackIdAndFrameIndex::iterator> track_iterator = track_db.search_by_track_id( 0 );
-  TrackDBCollectionByTrackIdAndFrameIndex::iterator beginning = track_iterator.first;
-  TrackDBCollectionByTrackIdAndFrameIndex::iterator end = track_iterator.second;
-
-  //Initialize variables
+  //One frame count per video
   uint32_t frame_count = 0;
-  double quality_sum = 0.0;
-  double minimum_quality = 1.0;
-  uint64_t total_coded_size = 0;
+  //Get frame rate for video
+  double frame_rate = alf.video_manifest().frame_rate();
+  //Initialize duration
+  double duration_in_seconds = 0.0;
 
-  //Set the track id
-  size_t track_id = (*beginning).track_id;
-
-  //Loop through one track until the iterator reaches the end
-  while(beginning != end)
+  //Loop through each track_id
+  for (const auto & track_id: track_ids)
   {
-    TrackData td = *beginning;
-    //We only count shown frames for quality and frame count
-    FrameInfo fi = frame_db.search_by_frame_id( td.frame_id );
-    if(fi.target_hash().shown) {
-      //Get an iterator to the quality data for a frame and read quality member variable
-      pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator> quality_iterator = quality_db.search_by_approximate_raster( fi.target_hash().output_hash );
-      double quality = (*quality_iterator.first).quality;
-      quality_sum += quality;
-      //Set the minimum quality if it is less than the current minimum
-      if(quality < minimum_quality) minimum_quality = quality;
-      frame_count++;
+    //Initialize variables
+    duration_in_seconds = 0.0;
+    frame_count = 0;
+    double quality_sum = 0.0;
+    double minimum_quality = 1.0;
+    uint64_t total_coded_size = 0;
+    //Get an iterator to the beginning and end of a track
+    pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
+    TrackDBIterator track_beginning = track_db_iterator.first;
+    TrackDBIterator track_end = track_db_iterator.second;
+
+    //Loop through one track until the iterator reaches the end
+    while(track_beginning != track_end)
+    {
+      //Get frame info for frame in track
+      FrameInfo fi = *track_beginning;
+      if(fi.target_hash().shown) {
+        //Get an iterator to the quality data for a frame and read quality member variable
+        pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator> quality_iterator = quality_db.search_by_approximate_raster( fi.target_hash().output_hash );
+        double quality = (*quality_iterator.first).quality;
+        quality_sum += quality;
+        //Set the minimum quality if it is less than the current minimum
+        if(quality < minimum_quality) minimum_quality = quality;
+        frame_count++;
+      }
+      //Get an iterator to the frame even if it is not shown. Total coded size includes both shown and unshown frames.
+      pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator> frame_iterator = frame_db.search_by_output_hash( fi.target_hash().output_hash );
+      uint64_t frame_length = (*frame_iterator.first).length();
+      total_coded_size += frame_length;
+      //Increment iterator to get next frame in track
+      track_beginning++;
     }
-    //Get an iterator to the frame even if it is not shown. Total coded size includes both shown and unshown frames.
-    pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator> frame_iterator = frame_db.search_by_output_hash( fi.target_hash().output_hash );
-    uint64_t frame_length = (*frame_iterator.first).length();
-    total_coded_size += frame_length;
-    //Increment iterator to get next frame in track
-    beginning++;
+    //Calculate average quality for track and print out relevant statistics
+    double average_quality = quality_sum / frame_count;
+
+    //Frame rate is frames per second
+    duration_in_seconds = frame_count / frame_rate;
+
+    //Bitrate is bits in the entire video (shown and unshown) over duration
+    double track_bitrate = (total_coded_size * 8) / duration_in_seconds;
+
+    cout << "Track ID: " << track_id << endl;
+    cout << "\t Total Coded Size: " << total_coded_size << " bytes" << endl;
+    cout << "\t Bitrate: " << track_bitrate << " bits/sec" << endl;
+    cout << "\t Average SSIM Quality: " << average_quality << endl;
+    cout << "\t Minimum SSIM Quality: " << minimum_quality << endl;
+
   }
-  //Calculate average quality for track and print out relevant statistics
-  double average_quality = quality_sum / frame_count;
 
-  //Frame rate is frames per second
-  double duration_in_seconds = frame_count / frame_rate;
-
-  //Bitrate is bits in the entire video (shown and unshown) over duration
-  double track_bitrate = (total_coded_size * 8) / duration_in_seconds;
-
-  cout << "Track ID: " << track_id << endl;
-  cout << "\t Total Coded Size: " << total_coded_size << " bytes" << endl;
-  cout << "\t Bitrate: " << track_bitrate << " bits/sec" << endl;
-  cout << "\t Average SSIM Quality: " << average_quality << endl;
-  cout << "\t Minimum SSIM Quality: " << minimum_quality << endl;
   cout << "Frame Count: " << frame_count << " total frames" << endl;
   cout << "Frame Rate: " << frame_rate << " frames/sec" << endl;
   cout << "Video Duration: " << duration_in_seconds << " sec" << endl;

--- a/src/frontend/alfalfa-describe.cc
+++ b/src/frontend/alfalfa-describe.cc
@@ -43,7 +43,8 @@ int main( int argc, char const *argv[] )
   //One frame count per video
   uint32_t frame_count = 0;
   //Get frame rate for video
-  double frame_rate = alf.video_manifest().frame_rate();
+  // FIXME fix the frame rate
+  double frame_rate = 24.0;
   //Initialize duration
   double duration_in_seconds = 0.0;
 

--- a/src/frontend/alfalfa-describe.cc
+++ b/src/frontend/alfalfa-describe.cc
@@ -23,88 +23,100 @@ using namespace std;
 
 int main( int argc, char const *argv[] )
 {
-  //Describes an alfalfa video from an alfalfa directory
-  if ( argc != 2 ) {
-    cerr << "usage: alfalfa-describe <alf>" << endl;
-    return EX_USAGE;
-  }
-
-  string alf_path( argv[ 1 ] );
-  PlayableAlfalfaVideo alf( alf_path );
-
-  //Get databases from alfalfa video
-  QualityDB quality_db = alf.quality_db();
-  TrackDB track_db = alf.track_db();
-  FrameDB frame_db = alf.frame_db();
-
-  //Get an iterator to the beginning and end of an unordered set of track ids
-  unordered_set<size_t> track_ids = *track_db.track_ids();
-
-  //One frame count per video
-  uint32_t frame_count = 0;
-  //Get frame rate for video
-  // FIXME fix the frame rate
-  double frame_rate = 24.0;
-  //Initialize duration
-  double duration_in_seconds = 0.0;
-
-  //Loop through each track_id
-  for (const auto & track_id: track_ids)
+  try
   {
-    //Initialize variables
-    duration_in_seconds = 0.0;
-    frame_count = 0;
-    double quality_sum = 0.0;
-    double minimum_quality = 1.0;
-    uint64_t total_coded_size = 0;
-    //Get an iterator to the beginning and end of a track
-    pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
-    TrackDBIterator track_beginning = track_db_iterator.first;
-    TrackDBIterator track_end = track_db_iterator.second;
-
-    //Loop through one track until the iterator reaches the end
-    while(track_beginning != track_end)
-    {
-      //Get frame info for frame in track
-      FrameInfo fi = *track_beginning;
-      if(fi.target_hash().shown) {
-        //Get an iterator to the quality data for a frame and read quality member variable
-        pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator> quality_iterator = quality_db.search_by_approximate_raster( fi.target_hash().output_hash );
-        double quality = (*quality_iterator.first).quality;
-        quality_sum += quality;
-        //Set the minimum quality if it is less than the current minimum
-        if(quality < minimum_quality) minimum_quality = quality;
-        frame_count++;
-      }
-      //Get an iterator to the frame even if it is not shown. Total coded size includes both shown and unshown frames.
-      pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator> frame_iterator = frame_db.search_by_output_hash( fi.target_hash().output_hash );
-      uint64_t frame_length = (*frame_iterator.first).length();
-      total_coded_size += frame_length;
-      //Increment iterator to get next frame in track
-      track_beginning++;
+    //Describes an alfalfa video from an alfalfa directory
+    if ( argc != 2 ) {
+      cerr << "Usage: " << argv[ 0 ] << " <alf>" << endl;
+      return EX_USAGE;
     }
-    //Calculate average quality for track and print out relevant statistics
-    double average_quality = quality_sum / frame_count;
 
-    //Frame rate is frames per second
-    duration_in_seconds = frame_count / frame_rate;
+    string alf_path( argv[ 1 ] );
+    PlayableAlfalfaVideo alf( alf_path );
 
-    //Bitrate is bits in the entire video (shown and unshown) over duration
-    double track_bitrate = (total_coded_size * 8) / duration_in_seconds;
+    //Get databases from alfalfa video
+    QualityDB quality_db = alf.quality_db();
+    TrackDB track_db = alf.track_db();
+    FrameDB frame_db = alf.frame_db();
 
-    cout << "Track ID: " << track_id << endl;
-    cout << "\t Total Coded Size: " << total_coded_size << " bytes" << endl;
-    cout << "\t Bitrate: " << track_bitrate << " bits/sec" << endl;
-    cout << "\t Average SSIM Quality: " << average_quality << endl;
-    cout << "\t Minimum SSIM Quality: " << minimum_quality << endl;
+    //Get an iterator to the beginning and end of an unordered set of track ids
+    unordered_set<size_t> track_ids = track_db.track_ids();
 
+    //One frame count per video
+    uint32_t frame_count = 0;
+    //Get frame rate for video
+    // FIXME fix the frame ratemake
+    double frame_rate = 24.0;
+    //Initialize duration
+    double duration_in_seconds = 0.0;
+
+    //Loop through each track_id
+    for ( const auto & track_id: track_ids )
+    {
+      //Initialize variables
+      duration_in_seconds = 0.0;
+      frame_count = 0;
+      double quality_sum = 0.0;
+      double minimum_quality = 1.0;
+      uint64_t total_coded_size = 0;
+      //Get an iterator to the beginning and end of a track
+      pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
+      TrackDBIterator track_beginning = track_db_iterator.first;
+      TrackDBIterator track_end = track_db_iterator.second;
+
+      //Loop through one track until the iterator reaches the end
+      while ( track_beginning != track_end )
+      {
+        //Get frame info for frame in track
+        FrameInfo fi = *track_beginning;
+        if ( fi.target_hash().shown ) {
+          //Get an iterator to the quality data for a frame and read quality member variable
+          pair<QualityDBCollectionByApproximateRaster::iterator, QualityDBCollectionByApproximateRaster::iterator> quality_iterator = quality_db.search_by_approximate_raster( fi.target_hash().output_hash );
+          double quality = ( *quality_iterator.first ).quality;
+          quality_sum += quality;
+
+          //Set the minimum quality if it is less than the current minimum
+          if ( quality < minimum_quality ) {
+            minimum_quality = quality;
+          }
+
+          frame_count++;
+        }
+        //Get an iterator to the frame even if it is not shown. Total coded size includes both shown and unshown frames.
+        pair<FrameDataSetCollectionByOutputHash::iterator, FrameDataSetCollectionByOutputHash::iterator> frame_iterator = frame_db.search_by_output_hash( fi.target_hash().output_hash );
+
+        uint64_t frame_length = ( *frame_iterator.first ).length();
+        cout << frame_length << " ";
+        total_coded_size += frame_length;
+        //Increment iterator to get next frame in track
+        track_beginning++;
+      }
+      //Calculate average quality for track and print out relevant statistics
+      double average_quality = quality_sum / frame_count;
+
+      //Frame rate is frames per second
+      duration_in_seconds = frame_count / frame_rate;
+
+      //Bitrate is bits in the entire video (shown and unshown) over duration
+      double track_bitrate = ( total_coded_size * 8 ) / duration_in_seconds;
+
+      cout << "Track ID: " << track_id << endl;
+      cout << "\t Total Coded Size: " << total_coded_size << " bytes" << endl;
+      cout << "\t Bitrate: " << track_bitrate << " bits/sec" << endl;
+      cout << "\t Average SSIM Quality: " << average_quality << endl;
+      cout << "\t Minimum SSIM Quality: " << minimum_quality << endl;
+
+    }
+
+    cout << "Frame Count: " << frame_count << " total frames" << endl;
+    cout << "Frame Rate: " << frame_rate << " frames/sec" << endl;
+    cout << "Video Duration: " << duration_in_seconds << " sec" << endl;
+    cout << "Video Width: " << alf.video_manifest().width() << " pixels" << endl;
+    cout << "Video Height: " << alf.video_manifest().height() << " pixels" << endl;
+  } catch ( const exception &e ) {
+    print_exception( argv[ 0 ], e );
+    return EXIT_FAILURE;
   }
 
-  cout << "Frame Count: " << frame_count << " total frames" << endl;
-  cout << "Frame Rate: " << frame_rate << " frames/sec" << endl;
-  cout << "Video Duration: " << duration_in_seconds << " sec" << endl;
-  cout << "Video Width: " << alf.video_manifest().width() << " pixels" << endl;
-  cout << "Video Height: " << alf.video_manifest().height() << " pixels" << endl;
-
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/src/frontend/alfalfa-play-super-manually.cc
+++ b/src/frontend/alfalfa-play-super-manually.cc
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <sstream>
+
+#include "player.hh"
+#include "display.hh"
+#include "exception.hh"
+#include "alfalfa_video.hh"
+#include "manifests.hh"
+#include "frame_db.hh"
+#include "filesystem.hh"
+#include "frame_db.hh"
+
+using namespace std;
+
+int main( int argc, char *argv[] )
+{
+  try {
+    if ( argc != 3 ) {
+      cerr << "Usage: " << argv[ 0 ] << " <alf> <track_id>" << endl;
+      return EXIT_FAILURE;
+    }
+
+    string alf_path( argv[ 1 ] );
+    PlayableAlfalfaVideo alf( alf_path );
+
+    stringstream type_converter( argv[2] );
+    size_t track_id;
+    type_converter >> track_id;
+
+    pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
+    TrackDBIterator track_beginning = track_db_iterator.first;
+    TrackDBIterator track_end = track_db_iterator.second;
+
+    FramePlayer player( alf.video_manifest().width(), alf.video_manifest().height() );
+    VideoDisplay display { player.example_raster() };
+
+    while(track_beginning != track_end) {
+      FrameInfo fi = *track_beginning;
+      Chunk frame = alf.get_chunk( fi );
+      Optional<RasterHandle> raster_optional = player.decode(frame);
+      if( raster_optional.initialized() ) {
+        display.draw( raster_optional.get() );
+      }
+      track_beginning++;
+    }
+  } catch ( const exception & e ) {
+    print_exception( argv[ 0 ], e );
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/frontend/alfalfa-play-super-manually.cc
+++ b/src/frontend/alfalfa-play-super-manually.cc
@@ -12,6 +12,7 @@
 
 using namespace std;
 
+//Plays one track of an alfalfa video
 int main( int argc, char *argv[] )
 {
   try {
@@ -20,27 +21,40 @@ int main( int argc, char *argv[] )
       return EXIT_FAILURE;
     }
 
+    //Create the path for the alfalfa video directory and call the constructor
     string alf_path( argv[ 1 ] );
     PlayableAlfalfaVideo alf( alf_path );
 
+    //Use string stream to convert track_id string to a size_t
     stringstream type_converter( argv[2] );
     size_t track_id;
     type_converter >> track_id;
 
+    //Get the track iterators from the alfalfa video for the specified track
+    //A track iterator can be used to find the frame info objects for a track
     pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
     TrackDBIterator track_beginning = track_db_iterator.first;
     TrackDBIterator track_end = track_db_iterator.second;
 
+    //Create a video player and a video display
     FramePlayer player( alf.video_manifest().width(), alf.video_manifest().height() );
     VideoDisplay display { player.example_raster() };
 
+    //Loop over the entire track frame by frame
     while(track_beginning != track_end) {
       FrameInfo fi = *track_beginning;
+
+      //Get the raw frame data from alfalfa video directory
       Chunk frame = alf.get_chunk( fi );
+
+      //Decode the frame
       Optional<RasterHandle> raster_optional = player.decode(frame);
+
+      //If the raster is decoded successfully, draw the raster to the display
       if( raster_optional.initialized() ) {
         display.draw( raster_optional.get() );
       }
+
       track_beginning++;
     }
   } catch ( const exception & e ) {

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -3,10 +3,11 @@ AM_CXXFLAGS = $(PICKY_CXXFLAGS) $(NODEBUG_CXXFLAGS)
 LDADD = ../format/libalfalfavideo.a ../format/protobufs/libalfalfaprotobufs.a ../decoder/libalfalfadecoder.a ../encoder/libalfalfaencoder.a ../util/libalfalfautil.a $(X264_LIBS) $(PROTOBUF_LIBS)
 check_PROGRAMS = extract-key-frames decode-to-stdout encode-loopback roundtrip \
 		 state-collisions ivfcopy framedb-test trackdb-test \
-                 framedb-benchmark ivfcompare import-test combine-test
+                 framedb-benchmark ivfcompare import-test combine-test alf-decode-to-stdout
 
 extract_key_frames_SOURCES = extract-key-frames.cc
 decode_to_stdout_SOURCES = decode-to-stdout.cc
+alf_decode_to_stdout_SOURCES = alf-decode-to-stdout.cc
 encode_loopback_SOURCES = encode-loopback.cc
 roundtrip_SOURCES = roundtrip.cc
 state_collisions_SOURCES = state-collisions.cc
@@ -18,13 +19,14 @@ combine_test_SOURCES = combine-test.cc
 framedb_benchmark_SOURCES = framedb-benchmark.cc
 ivfcompare_SOURCES = ivfcompare.cc
 
-dist_check_SCRIPTS = fetch-vectors.test decoding.test roundtrip-verify.test switch-test ivfcopy.test end-to-end-import.test end-to-end-combine.test
+dist_check_SCRIPTS = fetch-vectors.test decoding.test roundtrip-verify.test switch-test ivfcopy.test end-to-end-import.test end-to-end-combine.test alf-decoding.test
 
-TESTS = fetch-vectors.test decoding.test encode-loopback roundtrip-verify.test framedb-test ivfcopy.test trackdb-test end-to-end-import.test end-to-end-combine.test # switch-test
+TESTS = fetch-vectors.test decoding.test encode-loopback roundtrip-verify.test framedb-test ivfcopy.test trackdb-test end-to-end-import.test end-to-end-combine.test alf-decoding.test # switch-test
 
 # some tests depend on the test vectors having been fetched
 # represent the dependency in case of a parallel compile
 decoding.log: fetch-vectors.log
+alf-decoding.log: fetch-vectors.log
 roundtrip-verify.log: fetch-vectors.log
 ivfcopy.log: fetch-vectors.log
 end-to-end-import.log: fetch-vectors.log

--- a/src/tests/alf-decode-to-stdout.cc
+++ b/src/tests/alf-decode-to-stdout.cc
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <sstream>
+
+#include "player.hh"
+#include "exception.hh"
+#include "alfalfa_video.hh"
+#include "manifests.hh"
+#include "frame_db.hh"
+#include "filesystem.hh"
+#include "frame_db.hh"
+
+using namespace std;
+
+int main( int argc, char *argv[] )
+{
+  try {
+    if ( argc != 3 ) {
+      cerr << "Usage: " << argv[ 0 ] << " <alf> <track_id>" << endl;
+      return EXIT_FAILURE;
+    }
+
+    //Create the path for the alfalfa video directory and call the constructor
+    string alf_path( argv[ 1 ] );
+    PlayableAlfalfaVideo alf( alf_path );
+
+    //Use string stream to convert track_id string to a size_t
+    stringstream type_converter( argv[2] );
+    size_t track_id;
+    type_converter >> track_id;
+
+    //Get the track iterators from the alfalfa video for the specified track
+    //A track iterator can be used to find the frame info objects for a track
+    pair<TrackDBIterator, TrackDBIterator> track_db_iterator = alf.get_frames( track_id );
+    TrackDBIterator track_beginning = track_db_iterator.first;
+    TrackDBIterator track_end = track_db_iterator.second;
+
+    //Create a video player and a video display
+    FramePlayer player( alf.video_manifest().width(), alf.video_manifest().height() );
+
+    while(track_beginning != track_end) {
+      FrameInfo fi = *track_beginning;
+      //Get the raw frame data from alfalfa video directory
+      Chunk frame = alf.get_chunk( fi );
+      //Decode the frame
+      Optional<RasterHandle> raster_optional = player.decode(frame);
+      //If the raster is decoded successfully, dump the raster to stdout
+      if( raster_optional.initialized() ) {
+        raster_optional.get().get().dump( stdout ); //First get() for optional, second for RasterHandle
+      }
+      track_beginning++;
+    }
+  } catch ( const exception & e ) {
+      print_exception( argv[ 0 ], e );
+      return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/tests/alf-decoding.test
+++ b/src/tests/alf-decoding.test
@@ -1,0 +1,83 @@
+#!/usr/bin/env perl
+
+use strict;
+
+sub check {
+  my ( $sha1 ) = @_;
+  my $filename = 'test_vectors/' . ${sha1};
+  unless ( -e $filename ) {
+      print STDERR "$0: $sha1 not found, failing test.\n";
+      exit 1;
+  }
+
+  print STDERR "Checking $sha1... ";
+  my $alfalfa_video_directory = "./$sha1";
+  my $alfalfa_import_command = "../frontend/alfalfa-import $filename $alfalfa_video_directory";
+  system( $alfalfa_import_command );
+  my $decoded_sha1 = (split ' ', `./alf-decode-to-stdout $alfalfa_video_directory 0 2>&1 | sha1sum` )[ 0 ];
+  my $remove_alfalfa_directory_command = "rm -r $alfalfa_video_directory";
+  system( $remove_alfalfa_directory_command );
+  if ( $decoded_sha1 ne $sha1 ) {
+    print STDERR "$0: decoding mismatch: expected $sha1, got $decoded_sha1\n";
+    exit( 1 );
+  }
+  print STDERR "success.\n";
+};
+
+check( '04b68b0a642d8285303d2b8884fc374e09d28ae9' );
+check( '075d4eb18cbb2885d57eae5201cafb54bc43acca' );
+check( '07b5eb1e9741d90027c46166eaaff566c6bf934f' );
+check( '0b546dad90ddefea5085c7751b5fa2f117630b1c' );
+check( '0ccf971d82e0e868484f2b30d60f56785453e768' );
+check( '18c94ac52ca99bc3fc1521d30bf997e4d6657b51' );
+check( '1c75bf5cac928aef275d623040554d0f4cc7a3e8' );
+check( '2a4c049c2f8e3a19ee39ffd7074cecd68006a101' );
+check( '353ee97f6cc145f43be2f67c893ec0347d822cc1' );
+check( '4456925bdfd3492958ef7f884428b5c070b24bd5' );
+check( '45502fe01a62b82d498b83dc50824741402436db' );
+check( '48e475e2af456452f6258b8fe2882db6448086fc' );
+check( '4ebefe3c504e95db1be41f28d5357059519ea371' );
+check( '4f89bc5b3811ffc64975dc86a7087f6bed6fa297' );
+check( '4fca93f3956d6e0ccd6ee6d370a1dfeb2be4c996' );
+check( '503596b5a15a732da60243d0a67fa13884771efc' );
+check( '513f3ab8cc3baffae5bcd75d102b98df8cd3312d' );
+check( '590561acb2fcfdb46db9842b185da30af7a3dd03' );
+check( '6381d3149f5145212bba92c090f444d341101942' );
+check( '675cd7e88ebb28e4bcd2bf414bb288f44e4edc7f' );
+check( '7d865ecf465b5883180fb6d327ada6de110a2fd0' );
+check( '89ca6f0ce420bb63e5c621d0711beae551a51eef' );
+check( '8bf4c5bb27fd7ee378fee0eb46013b8f004469af' );
+check( '8e2f9c93cad193f0a26dd04dc46ac3dc45c5a041' );
+check( '9038efedf99ce6a279db7386f8b492bdba30dee6' );
+check( '95584facca028262893867ee52d20f7831407040' );
+check( '9a9e1e3602d48715c9a9f4204d73885c401dbb0f' );
+check( '9b233ad3682e91cd01b17af30d8d53d1d5f3a928' );
+check( 'a4dace04a77fc9f969a8d7a645c99c0271f1f73e' );
+check( 'a61782d062ed13ca22b98ffa29feb575bfb97ce9' );
+check( 'a6ad4fd7834174f06f94f6bde70f3923103cdcb9' );
+check( 'a82d97046361ff6467a2297c33aff4a14872e6b8' );
+check( 'ac11b3f6d50d743f713f7870b7202533f0eb2393' );
+check( 'ad04fe4122ec4bc02a893f6da48d3158ab1838e0' );
+check( 'b1f51b2cb78073e675bf763436af39c3785972a2' );
+check( 'b942a29bf527d06aa13ffcef089faa7fce75bd5c' );
+check( 'ba8432e30609fe1c59e02c052e196e0c3e2ca471' );
+check( 'c401f35bb38fb2d10b486618ddb61e6df560bec4' );
+check( 'c4824e97501131b5d5b12628bc163f263b1794da' );
+check( 'ced8ea722f3471fc0fed7de6148683a543ade151' );
+check( 'd1e7b447642b76121f45c2511bc8315f6b997207' );
+check( 'd4e9f670c4df95d60d0bc95f393d1decda4dbca1' );
+check( 'd688f0a9f471d3107465b009a998fd68a9d281ae' );
+check( 'dbdd07032180b63689fc0475cdfac1ed927cd253' );
+check( 'de0dc731cd03f1a523a4f8477326d5030f26307e' );
+check( 'df225756c61e0dd77404c3f4a033624f0ad35a55' );
+check( 'e01c6f92f23eefecb1e120230a2c4b2767cce066' );
+check( 'e1230f8fa11ac592e34689d32cb6b0532fe627fc' );
+check( 'e3bc5f0cddad4d30ed53283788dd97a743c51959' );
+check( 'e508817f07a0e910e68a49d5fab449bf6bfd7479' );
+check( 'ea6ba2499a47208ee6393d164d5447c1649cf285' );
+check( 'eeeb9bf9e0fbcf543da64ad6353c6500534ccef7' );
+check( 'ff2941dde20090835032c32c0644b6d401610c57' );
+
+print STDERR "$0: all tests passed\n";
+
+exit 0;

--- a/src/tests/extract-key-frames.cc
+++ b/src/tests/extract-key-frames.cc
@@ -20,7 +20,7 @@ int main( int argc, char *argv[] )
       throw Unsupported( "not a VP8 file" );
     }
 
-    std::vector< uint32_t > key_frames;
+    vector< uint32_t > key_frames;
 
     /* count key frames */
     unsigned int num_key_frames = 0;

--- a/src/tests/framedb-benchmark.cc
+++ b/src/tests/framedb-benchmark.cc
@@ -21,8 +21,8 @@ int main()//( int argc, char const *argv[] )
 
   FrameDB fdb( "fake.db", "ALFAFRDB" );
 
-  std::string line;
-  std::string frame_name;
+  string line;
+  string frame_name;
   size_t offset;
   size_t q;
 
@@ -60,8 +60,8 @@ int main()//( int argc, char const *argv[] )
   cout << "stream_manifest read completed." << endl;
 
   DecoderHash decoder_hash(0, 0, 0, 0, 0);
-  std::chrono::time_point<std::chrono::system_clock> start;
-  std::chrono::duration<double> elapsed_seconds;
+  chrono::time_point<chrono::system_clock> start;
+  chrono::duration<double> elapsed_seconds;
 
   int stream_idx = 0;
 
@@ -72,17 +72,17 @@ int main()//( int argc, char const *argv[] )
       decoder_hash.update( frame.target_hash() );
 
       // looking for the decoder hash using search_by_source_hash method.
-      start = std::chrono::system_clock::now();
+      start = chrono::system_clock::now();
       auto result = fdb.search_by_decoder_hash( decoder_hash );
 
       for ( auto it = result.first; it != result.second; it++ ) {
 
       }
-      elapsed_seconds = std::chrono::system_clock::now() - start;
+      elapsed_seconds = chrono::system_clock::now() - start;
       fdb_hashed_search_times.push_back( elapsed_seconds.count() );
 
       // looking for the decoder hash using linear search.
-      start = std::chrono::system_clock::now();
+      start = chrono::system_clock::now();
 
       for ( auto it = fdb.begin(); it != fdb.end(); it++ ) {
         if ( decoder_hash.can_decode( it->source_hash() ) ) {
@@ -90,7 +90,7 @@ int main()//( int argc, char const *argv[] )
         }
       }
 
-      elapsed_seconds = std::chrono::system_clock::now() - start;
+      elapsed_seconds = chrono::system_clock::now() - start;
       fdb_linear_search_times.push_back( elapsed_seconds.count() );
     }
   }
@@ -98,9 +98,9 @@ int main()//( int argc, char const *argv[] )
   sort( fdb_linear_search_times.begin(), fdb_linear_search_times.end() );
   sort( fdb_hashed_search_times.begin(), fdb_hashed_search_times.end() );
 
-  double fdb_linear_search_mean = std::accumulate(fdb_linear_search_times.begin(), fdb_linear_search_times.end(), 0.0) /
+  double fdb_linear_search_mean = accumulate(fdb_linear_search_times.begin(), fdb_linear_search_times.end(), 0.0) /
    fdb_linear_search_times.size();
-  double fdb_hashed_search_mean = std::accumulate(fdb_hashed_search_times.begin(), fdb_hashed_search_times.end(), 0.0) /
+  double fdb_hashed_search_mean = accumulate(fdb_hashed_search_times.begin(), fdb_hashed_search_times.end(), 0.0) /
     fdb_hashed_search_times.size();
 
   double fdb_linear_search_median = fdb_linear_search_times[ fdb_linear_search_times.size() / 2 ];

--- a/src/tests/framedb-test.cc
+++ b/src/tests/framedb-test.cc
@@ -10,7 +10,7 @@ using namespace std;
 
 int main()
 {
-  std::string db1 = "test-frame-db";
+  string db1 = "test-frame-db";
 
   FrameDB fdb1( db1, "ALFAFRDB", OpenMode::TRUNCATE );
 
@@ -39,7 +39,7 @@ int main()
   FrameDB fdb2( db1, "ALFAFRDB", OpenMode::READ );
 
   size_t state_hash, continuation_hash, last_hash, golden_hash, alt_hash;
-  set<std::string> hashed_search_results, linear_search_results;
+  set<string> hashed_search_results, linear_search_results;
 
   for ( auto it = fdb1.begin(); it != fdb1.end(); it++ ) {
     state_hash = it->source_hash().state_hash.initialized() ? it->source_hash().state_hash.get() : rand();

--- a/src/util/file.cc
+++ b/src/util/file.cc
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-File::File( const std::string & filename )
+File::File( const string & filename )
   : fd_( SystemCall( filename, open( filename.c_str(), O_RDONLY ) ) ),
     size_( fd_.size() ),
     mmap_region_( MMap_Region( size_, PROT_READ, MAP_SHARED, fd_.num() ) ),

--- a/src/util/file_descriptor.hh
+++ b/src/util/file_descriptor.hh
@@ -8,8 +8,6 @@
 #include "exception.hh"
 #include "chunk.hh"
 
-using namespace std;
-
 class FileDescriptor
 {
 private:
@@ -47,23 +45,23 @@ public:
     other.fd_ = -1;
   }
 
-  string::const_iterator write( const string::const_iterator & begin,
-    const string::const_iterator & end )
+  std::string::const_iterator write( const std::string::const_iterator & begin,
+    const std::string::const_iterator & end )
   {
     if ( begin >= end ) {
-      throw runtime_error( "nothing to write" );
+      throw std::runtime_error( "nothing to write" );
     }
 
     ssize_t bytes_written = SystemCall( "write", ::write( fd_, &*begin, end - begin ) );
 
     if ( bytes_written == 0 ) {
-      throw runtime_error( "write returned 0" );
+      throw std::runtime_error( "write returned 0" );
     }
 
     return begin + bytes_written;
   }
 
-  string::const_iterator write( const std::string & buffer, const bool write_all = true )
+  std::string::const_iterator write( const std::string & buffer, const bool write_all = true )
   {
     auto it = buffer.begin();
 
@@ -79,9 +77,9 @@ public:
     Chunk amount_left_to_write = buffer;
     while ( amount_left_to_write.size() > 0 ) {
       ssize_t bytes_written = SystemCall( "write",
-					  ::write( fd_, amount_left_to_write.buffer(), amount_left_to_write.size() ) );
+        ::write( fd_, amount_left_to_write.buffer(), amount_left_to_write.size() ) );
       if ( bytes_written == 0 ) {
-	throw internal_error( "write", "returned 0" );
+        throw internal_error( "write", "returned 0" );
       }
       amount_left_to_write = amount_left_to_write( bytes_written );
     }

--- a/src/util/filesystem.cc
+++ b/src/util/filesystem.cc
@@ -11,39 +11,39 @@
 
 using namespace std;
 
-void FileSystem::create_directory( const std::string & path )
+void FileSystem::create_directory( const string & path )
 {
   SystemCall( "mkdir " + path,
 	      mkdir( path.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH ) );
 }
 
-std::string FileSystem::append( const std::string & path1, const std::string & path2 )
+string FileSystem::append( const string & path1, const string & path2 )
 {
   return path1 + "/" + path2;
 }
 
-void FileSystem::change_directory( const std::string & path )
+void FileSystem::change_directory( const string & path )
 {
   SystemCall( "chdir " + path, chdir( path.c_str() ) );
 }
 
-std::string FileSystem::get_basename( const std::string & path )
+string FileSystem::get_basename( const string & path )
 {
   return basename( path.c_str() );
 }
 
-std::string FileSystem::get_realpath( const std::string & path )
+string FileSystem::get_realpath( const string & path )
 {
   char resolved_path[ PATH_MAX ];
 
   if ( realpath( path.c_str(), resolved_path ) == nullptr ) {
     throw unix_error( "realpath (" + path + ")" );
   }
-  
+
   return resolved_path;
 }
 
-void FileSystem::create_symbolic_link( const std::string & path1, const std::string & path2 )
+void FileSystem::create_symbolic_link( const string & path1, const string & path2 )
 {
   SystemCall( "symlink", symlink( path1.c_str(), path2.c_str() ) );
 }

--- a/src/util/ivf.cc
+++ b/src/util/ivf.cc
@@ -52,7 +52,7 @@ Chunk IVF::frame( const uint32_t & index ) const
   return file_( entry.first, entry.second );
 }
 
-std::pair<uint64_t, uint32_t> IVF::frame_location( const uint32_t & index ) const
+pair<uint64_t, uint32_t> IVF::frame_location( const uint32_t & index ) const
 {
   return frame_index_.at( index );
 }

--- a/src/util/subprocess.cc
+++ b/src/util/subprocess.cc
@@ -1,10 +1,12 @@
 #include "subprocess.hh"
 #include "exception.hh"
 
+using namespace std;
+
 Subprocess::Subprocess()
 {}
 
-void Subprocess::call( const std::string & command, const std::string & type )
+void Subprocess::call( const string & command, const string & type )
 {
   file_.reset( popen( command.c_str(), type.c_str() ) );
 
@@ -25,7 +27,7 @@ int Subprocess::wait()
   return ret;
 }
 
-size_t Subprocess::write_string( const std::string & str )
+size_t Subprocess::write_string( const string & str )
 {
   if ( file_ == nullptr ) {
     throw unix_error( "nowhere to write" );

--- a/src/util/subprocess.hh
+++ b/src/util/subprocess.hh
@@ -5,8 +5,6 @@
 #include <string>
 #include <memory>
 
-using namespace std;
-
 class Subprocess
 {
 private:
@@ -14,9 +12,9 @@ private:
 
 public:
   Subprocess();
-  void call( const string & command, const string & type = "w" );
+  void call( const std::string & command, const std::string & type = "w" );
 
-  size_t write_string( const string & str );
+  size_t write_string( const std::string & str );
   FILE * stream() { return file_.get(); }
 
   int wait();


### PR DESCRIPTION
Remove unnecessary `std::`s and `using namespace std;`s.
Remove default constructors for `FrameInfo`, `SourceHash` and `TargetHash`.