### PR TITLE
Fix clobbering bug

### DIFF
--- a/src/format/alfalfa_video.hh
+++ b/src/format/alfalfa_video.hh
@@ -33,6 +33,7 @@
 enum class OpenMode
 {
   READ,
+  RW,
   Create,
 };
 
@@ -51,6 +52,7 @@ public:
   public:
     VideoDirectory( const std::string & name, const OpenMode mode );
 
+    OpenMode mode() const;
     FileDescriptor video_manifest() const;
     FileDescriptor raster_list() const;
     FileDescriptor quality_db() const;


### PR DESCRIPTION
@keithw: I tested this on alfalfa-combine, and it seemed to work fine:

    deepakn94@alfalfa-framemaker:~/alfalfa/src$ ~/alfalfa/src/frontend/alfalfa-combine ~/moonrise_alfs/moonrise-cq10.alf/ ~/moonrise_alfs/moonrise.alf/ ~/moonrise_alfs/expt.alf
    deepakn94@alfalfa-framemaker:~/alfalfa/src$ ~/alfalfa/src/frontend/alfalfa-combine ~/moonrise_alfs/moonrise-cq10.alf/ ~/moonrise_alfs/moonrise.alf/ ~/moonrise_alfs/expt.alf
    deepakn94@alfalfa-framemaker:~/alfalfa/src$ ~/alfalfa/src/frontend/alfalfa-combine ~/moonrise_alfs/moonrise-cq10.alf/ ~/moonrise_alfs/moonrise.alf/ ~/moonrise_alfs/expt.alf
    deepakn94@alfalfa-framemaker:~/alfalfa/src$ ~/alfalfa/src/frontend/alfalfa-describe ~/moonrise_alfs/expt.alf/
    Track ID: 5
         Total Coded Size: 35231659 bytes
         Bitrate: 2.3087e+06 bits/sec
         Average SSIM Quality: 1
         Minimum SSIM Quality: 1
    Track ID: 4
         Total Coded Size: 42693857 bytes
         Bitrate: 2.79769e+06 bits/sec
         Average SSIM Quality: 0.994398
         Minimum SSIM Quality: 0.978095
    Track ID: 3
         Total Coded Size: 35231659 bytes
         Bitrate: 2.3087e+06 bits/sec
         Average SSIM Quality: 1
         Minimum SSIM Quality: 1
    Track ID: 2
         Total Coded Size: 42693857 bytes
         Bitrate: 2.79769e+06 bits/sec
         Average SSIM Quality: 0.994398
         Minimum SSIM Quality: 0.978095
    Track ID: 1
         Total Coded Size: 35231659 bytes
         Bitrate: 2.3087e+06 bits/sec
         Average SSIM Quality: 1
         Minimum SSIM Quality: 1
    Track ID: 0
         Total Coded Size: 42693857 bytes
         Bitrate: 2.79769e+06 bits/sec
         Average SSIM Quality: 0.994398
         Minimum SSIM Quality: 0.978095
    Frame Count: 2930 total frames
    Frame Rate: 24 frames/sec
    Video Duration: 122.083 sec
    Video Width: 1280 pixels
    Video Height: 720 pixels